### PR TITLE
Add sliding window TPM calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Or clone and symlink: `git clone https://github.com/levibe/claude-code-statuslin
 - Caps untracked line counting at 10k to avoid slowdowns on large diffs
 - Works in empty repos, detached HEAD, and normal branches
 - Uses `--no-optional-locks` on all git calls to prevent lock contention
-- Prevents model name from bleeding across sessions ([CC bug](https://github.com/anthropics/claude-code/issues/19570))
+- TPM uses a 5-minute sliding window for real-time throughput
+- Fixes model name bleeding across sessions ([CC bug](https://github.com/anthropics/claude-code/issues/19570))
 
 
 ## Contributing

--- a/statusline.sh
+++ b/statusline.sh
@@ -22,6 +22,14 @@ eval "$(echo "$input" | jq -r '
 cwd=${cwd:-}; session_id=${session_id:-}; used=${used:-0}; model=${model:-unknown}
 total_in=${total_in:-0}; total_out=${total_out:-0}; duration_ms=${duration_ms:-0}
 
+# Session-scoped state key (used by model cache and sliding window TPM)
+safe_id=$(printf '%s' "$session_id" | tr -dc 'a-zA-Z0-9_-')
+
+# Temp file cleanup (set once, covers all temp files created below)
+tmpfile=""
+untracked_list=""
+trap 'rm -f "$tmpfile" "$untracked_list"' EXIT
+
 # Tokens per minute (full-session average as default)
 total_tokens=$((total_in + total_out))
 if [ "$duration_ms" -gt 0 ]; then
@@ -40,10 +48,6 @@ fi
 # Update rule: only replace the cached model when duration_ms has increased,
 # meaning this session processed a real assistant turn.
 # A model change with no new turn will take effect on the next turn.
-#
-# Each session has a unique session_id → unique safe_id → no cross-session
-# file collisions, so a non-atomic write is safe here.
-safe_id=$(printf '%s' "$session_id" | tr -dc 'a-zA-Z0-9_-')
 if [ -n "$safe_id" ]; then
   model_file="/tmp/${MODEL_STATE_PREFIX}-${safe_id}"
   if [ -f "$model_file" ]; then
@@ -70,14 +74,13 @@ if [ -n "$safe_id" ]; then
 fi
 
 # Sliding window TPM (overrides full-session average when enough data)
-tmpfile=""
 if [ -n "$safe_id" ]; then
   state_file="/tmp/${TPM_STATE_PREFIX}-${safe_id}"
   [ -f "$state_file" ] || : > "$state_file"
 
   # Detect session restart (duration_ms went backwards)
   last_ms=$(tail -n 1 "$state_file" 2>/dev/null | awk '$1 ~ /^[0-9]+$/ { print $1 }')
-  if [ -n "$last_ms" ] && [ "$duration_ms" -lt "$last_ms" ]; then
+  if [ -n "$last_ms" ] && [ "$duration_ms" -lt "$last_ms" ] 2>/dev/null; then
     : > "$state_file"
   fi
 
@@ -85,16 +88,17 @@ if [ -n "$safe_id" ]; then
   [ "$cutoff" -lt 0 ] && cutoff=0
 
   tmpfile=$(mktemp "/tmp/${TPM_STATE_PREFIX}-XXXXXX")
-  trap 'rm -f "$tmpfile"' EXIT
 
   window_tpm=$(awk -v cutoff="$cutoff" -v cur_ms="$duration_ms" -v cur_tok="$total_tokens" -v tmpfile="$tmpfile" '
-    BEGIN { oldest_ms = ""; oldest_tok = "" }
+    BEGIN { oldest_ms = ""; oldest_tok = ""; last_ms = "" }
     $1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ && $1 + 0 >= cutoff {
       print > tmpfile
       if (oldest_ms == "") { oldest_ms = $1 + 0; oldest_tok = $2 + 0 }
+      last_ms = $1 + 0
     }
     END {
-      printf "%s %s\n", cur_ms, cur_tok > tmpfile
+      if (last_ms != cur_ms + 0)
+        printf "%s %s\n", cur_ms, cur_tok > tmpfile
       close(tmpfile)
       delta_ms = cur_ms - oldest_ms
       delta_tok = cur_tok - oldest_tok
@@ -103,7 +107,7 @@ if [ -n "$safe_id" ]; then
     }
   ' "$state_file" 2>/dev/null)
 
-  mv "$tmpfile" "$state_file"
+  [ -f "$tmpfile" ] && mv "$tmpfile" "$state_file"
 
   # Negative deltas (e.g. context window reset) produce negative TPM — intentionally ignored
   if [ -n "$window_tpm" ] && [ "$window_tpm" -gt 0 ] 2>/dev/null; then
@@ -164,7 +168,6 @@ if [ -n "$cwd" ]; then
     untracked_lines=0
     untracked_capped=0
     untracked_list=$(mktemp)
-    trap 'rm -f "$tmpfile" "$untracked_list"' EXIT  # extends earlier tmpfile trap
     git --no-optional-locks -C "$cwd" ls-files --others --exclude-standard -z 2>/dev/null > "$untracked_list"
     total_untracked=$(tr -cd '\0' < "$untracked_list" | wc -c | tr -d ' ')
     total_untracked=${total_untracked:-0}

--- a/statusline.sh
+++ b/statusline.sh
@@ -1,11 +1,15 @@
 #!/bin/sh
 # Status line: ⌥ branch  +N -N  ✦ model  ▓▓░░ N%  ⚡N tpm
 
+TPM_STATE_PREFIX="claude-code-statusline-tpm"
+TPM_WINDOW_MS=300000  # 5 minutes
+
 input=$(cat)
 
 # Single jq call to extract all fields (floor handles potential floats)
 eval "$(echo "$input" | jq -r '
   "cwd=\(.cwd // "" | @sh)",
+  "session_id=\(.session_id // "" | @sh)",
   "used=\(.context_window.used_percentage // 0 | floor | @sh)",
   "model=\(.model.display_name // "unknown" | sub(" *\\(.*\\)"; "") | @sh)",
   "total_in=\(.context_window.total_input_tokens // 0 | floor | @sh)",
@@ -14,15 +18,58 @@ eval "$(echo "$input" | jq -r '
 ')"
 
 # Defaults if jq fails or fields are missing
-cwd=${cwd:-}; used=${used:-0}; model=${model:-unknown}
+cwd=${cwd:-}; session_id=${session_id:-}; used=${used:-0}; model=${model:-unknown}
 total_in=${total_in:-0}; total_out=${total_out:-0}; duration_ms=${duration_ms:-0}
 
-# Tokens per minute
+# Tokens per minute (full-session average as default)
 total_tokens=$((total_in + total_out))
 if [ "$duration_ms" -gt 0 ]; then
   tpm=$(( (total_tokens * 60000) / duration_ms ))
 else
   tpm=0
+fi
+
+# Sliding window TPM (overrides full-session average when enough data)
+tmpfile=""
+safe_id=$(printf '%s' "$session_id" | tr -dc 'a-zA-Z0-9_-')
+if [ -n "$safe_id" ]; then
+  state_file="/tmp/${TPM_STATE_PREFIX}-${safe_id}"
+  [ -f "$state_file" ] || : > "$state_file"
+
+  # Detect session restart (duration_ms went backwards)
+  last_ms=$(tail -n 1 "$state_file" 2>/dev/null | awk '$1 ~ /^[0-9]+$/ { print $1 }')
+  if [ -n "$last_ms" ] && [ "$duration_ms" -lt "$last_ms" ]; then
+    : > "$state_file"
+  fi
+
+  cutoff=$((duration_ms - TPM_WINDOW_MS))
+  [ "$cutoff" -lt 0 ] && cutoff=0
+
+  tmpfile=$(mktemp "/tmp/${TPM_STATE_PREFIX}-XXXXXX")
+  trap 'rm -f "$tmpfile"' EXIT
+
+  window_tpm=$(awk -v cutoff="$cutoff" -v cur_ms="$duration_ms" -v cur_tok="$total_tokens" -v tmpfile="$tmpfile" '
+    BEGIN { oldest_ms = ""; oldest_tok = "" }
+    $1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ && $1 + 0 >= cutoff {
+      print > tmpfile
+      if (oldest_ms == "") { oldest_ms = $1 + 0; oldest_tok = $2 + 0 }
+    }
+    END {
+      printf "%s %s\n", cur_ms, cur_tok > tmpfile
+      close(tmpfile)
+      delta_ms = cur_ms - oldest_ms
+      delta_tok = cur_tok - oldest_tok
+      if (oldest_ms != "" && delta_ms > 0)
+        printf "%d", (delta_tok * 60000) / delta_ms
+    }
+  ' "$state_file" 2>/dev/null)
+
+  mv "$tmpfile" "$state_file"
+
+  # Negative deltas (e.g. context window reset) produce negative TPM — intentionally ignored
+  if [ -n "$window_tpm" ] && [ "$window_tpm" -gt 0 ] 2>/dev/null; then
+    tpm=$window_tpm
+  fi
 fi
 
 # 5-char progress bar (each bar = 20%)
@@ -78,7 +125,7 @@ if [ -n "$cwd" ]; then
     untracked_lines=0
     untracked_capped=0
     untracked_list=$(mktemp)
-    trap 'rm -f "$untracked_list"' EXIT
+    trap 'rm -f "$tmpfile" "$untracked_list"' EXIT  # extends earlier tmpfile trap
     git --no-optional-locks -C "$cwd" ls-files --others --exclude-standard -z 2>/dev/null > "$untracked_list"
     total_untracked=$(tr -cd '\0' < "$untracked_list" | wc -c | tr -d ' ')
     total_untracked=${total_untracked:-0}


### PR DESCRIPTION
## Summary

- Replace full-session-average TPM with a 5-minute sliding window for real-time token rate display
- Per-session state file in `/tmp/` tracks `(duration_ms, total_tokens)` pairs, pruning entries outside the window
- Falls back to full-session average when insufficient window data
- Detects session restarts (duration_ms regression) and resets state
- Suppresses duplicate entries when polled with no new activity
- Consolidates EXIT trap and hoists shared `safe_id` computation

Closes #2

## Test plan

- [ ] Verify TPM displays and updates during active conversation
- [ ] Verify TPM falls back to full-session average on first invocation
- [ ] Verify state file is pruned to 5-minute window
- [ ] Verify session restart resets the state file
- [ ] Verify no duplicate rows accumulate during idle polling
- [ ] Verify model cache still works correctly after merge with main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TPM (tokens per minute) throughput now calculated using a 5-minute sliding window for real-time accuracy
  * Enhanced session restart handling for accurate TPM tracking

* **Bug Fixes**
  * Model name bleeding prevention across sessions confirmed and maintained

* **Documentation**
  * Updated README with details on real-time TPM throughput calculation methodology

<!-- end of auto-generated comment: release notes by coderabbit.ai -->