### PR TITLE
Add color tiers to TPM bolt

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Or clone and symlink: `git clone https://github.com/levibe/claude-code-statuslin
 ## Notes
 
 - Context bar color shifts from grey to yellow-green to yellow to orange as usage increases
+- Tokens per minute bolt gains color as you speed up
 - Tracks text diffs, untracked files, and binary file changes (binary files count as +1 added or -1 removed)
 - Caps line counting at 10k to avoid slowdowns on large diffs
 - Works in empty repos, detached HEAD, and normal branches

--- a/statusline.sh
+++ b/statusline.sh
@@ -216,5 +216,16 @@ if [ "$tpm" -gt 0 ]; then
   else
     tpm_display="$tpm"
   fi
-  printf "${sep}${dim}⚡%s tpm${reset}" "$tpm_display"
+  if [ "$tpm" -ge 20000 ]; then
+    bolt="\033[38;5;57m⚡${dim}"   # deep violet
+  elif [ "$tpm" -ge 10000 ]; then
+    bolt="\033[91m⚡${dim}"        # red
+  elif [ "$tpm" -ge 5000 ]; then
+    bolt="\033[38;5;209m⚡${dim}"  # orange
+  elif [ "$tpm" -ge 1000 ]; then
+    bolt="\033[93m⚡${dim}"        # yellow
+  else
+    bolt="⚡"
+  fi
+  printf "${sep}${dim}${bolt}%s tpm${reset}" "$tpm_display"
 fi


### PR DESCRIPTION
## Summary
- Bolt icon gains color as token throughput increases: yellow (1k), orange (5k), red (10k), deep violet (20k)
- Adds a note to the README

## Test plan
- [ ] Verify each color tier renders correctly in terminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tokens per minute indicator now features dynamic, speed-based colors. The indicator changes color across multiple performance thresholds, providing real-time visual feedback as your speed increases.

* **Documentation**
  * Updated documentation to describe the color-coding behavior of the performance indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->