### PR TITLE
Add subagent token tracking to TPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,17 +59,12 @@ Or clone and symlink: `git clone https://github.com/levibe/claude-code-statuslin
 `brew install jq git` or `apt install jq git`
 
 
-## Limitations
-
-- Subagent token usage is not tracked
-
-
 ## Notes
 
 - Context bar color shifts from grey to yellow-green to yellow to orange as usage increases
 - Tokens per minute bolt gains color as you speed up
 - Tracks text diffs, untracked files, and binary file changes (binary files count as +1 added or -1 removed)
-- TPM uses a 5-minute sliding window
+- TPM uses a 5-minute sliding window and includes subagent token usage
 - Fixes model name bleeding across sessions ([CC bug](https://github.com/anthropics/claude-code/issues/19570))
 - Caps line counting at 10k to avoid slowdowns on large diffs
 - Works in empty repos, detached HEAD, and normal branches

--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ Or clone and symlink: `git clone https://github.com/levibe/claude-code-statuslin
 - Caps line counting at 10k to avoid slowdowns on large diffs
 - Works in empty repos, detached HEAD, and normal branches
 - Uses `--no-optional-locks` on all git calls to prevent lock contention
+- Validates model names to filter garbled input from Claude Code
+
+
+## Development
+
+Run the test suite:
+
+```bash
+brew install bats-core  # https://bats-core.readthedocs.io/en/stable/installation.html
+bats test/
+```
 
 
 ## Contributing

--- a/statusline.sh
+++ b/statusline.sh
@@ -11,6 +11,7 @@ input=$(cat)
 eval "$(echo "$input" | jq -r '
   "cwd=\(.cwd // "" | @sh)",
   "session_id=\(.session_id // "" | @sh)",
+  "transcript_path=\(.transcript_path // "" | @sh)",
   "used=\(.context_window.used_percentage // 0 | floor | @sh)",
   "model=\(.model.display_name // "unknown" | sub(" *\\(.*\\)"; "") | @sh)",
   "total_in=\(.context_window.total_input_tokens // 0 | floor | @sh)",
@@ -19,7 +20,8 @@ eval "$(echo "$input" | jq -r '
 ')"
 
 # Defaults if jq fails or fields are missing
-cwd=${cwd:-}; session_id=${session_id:-}; used=${used:-0}; model=${model:-unknown}
+cwd=${cwd:-}; session_id=${session_id:-}; transcript_path=${transcript_path:-}
+used=${used:-0}; model=${model:-unknown}
 total_in=${total_in:-0}; total_out=${total_out:-0}; duration_ms=${duration_ms:-0}
 
 # Session-scoped state key (used by model cache and sliding window TPM)
@@ -32,6 +34,19 @@ trap 'rm -f "$tmpfile" "$untracked_list"' EXIT
 
 # Tokens per minute (full-session average as default)
 total_tokens=$((total_in + total_out))
+
+# Subagent tokens (not included in main session totals)
+if [ -n "$transcript_path" ]; then
+  subagent_dir="${transcript_path%.jsonl}/subagents"
+  if [ -d "$subagent_dir" ]; then
+    subagent_tokens=$(cat "$subagent_dir"/agent-*.jsonl 2>/dev/null \
+      | jq -r 'select(.type == "assistant") | "\(.message.id) \(.message.usage.input_tokens // 0) \(.message.usage.output_tokens // 0)"' 2>/dev/null \
+      | awk '{usage[$1]=$2" "$3} END {for(id in usage){split(usage[id],a);s+=a[1]+a[2]} print s+0}')
+    subagent_tokens=${subagent_tokens:-0}
+    [ "$subagent_tokens" -gt 0 ] 2>/dev/null && total_tokens=$((total_tokens + subagent_tokens))
+  fi
+fi
+
 if [ "$duration_ms" -gt 0 ]; then
   tpm=$(( (total_tokens * 60000) / duration_ms ))
 else

--- a/statusline.sh
+++ b/statusline.sh
@@ -25,6 +25,13 @@ cwd=${cwd:-}; session_id=${session_id:-}; transcript_path=${transcript_path:-}
 used=${used:-0}; model=${model:-unknown}
 total_in=${total_in:-0}; total_out=${total_out:-0}; duration_ms=${duration_ms:-0}
 
+# Validate model name: must match "Name N.N" pattern (e.g. "Opus 4.6", "Sonnet 4.6", "Haiku 4.5")
+# Garbled names from Claude Code (e.g. "Op.6") are treated as unknown so they don't pollute the cache
+case "$model" in
+  unknown) ;;
+  *) echo "$model" | grep -qE '^[A-Z][a-z]+ [0-9]+\.[0-9]+$' || model="unknown" ;;
+esac
+
 # Session-scoped state key (used by model cache and sliding window TPM)
 safe_id=$(printf '%s' "$session_id" | tr -dc 'a-zA-Z0-9_-')
 

--- a/statusline.sh
+++ b/statusline.sh
@@ -4,6 +4,7 @@
 TPM_STATE_PREFIX="claude-code-statusline-tpm"
 TPM_WINDOW_MS=300000  # 5 minutes
 MODEL_STATE_PREFIX="claude-code-statusline-model"
+SUBAGENT_STATE_PREFIX="claude-code-statusline-subagent"
 
 input=$(cat)
 
@@ -35,17 +36,35 @@ trap 'rm -f "$tmpfile" "$untracked_list"' EXIT
 # Tokens per minute (full-session average as default)
 total_tokens=$((total_in + total_out))
 
-# Subagent tokens (not included in main session totals)
-if [ -n "$transcript_path" ]; then
+# Subagent tokens (mtime-cached to avoid re-parsing unchanged files)
+subagent_tokens=0
+if [ -n "$transcript_path" ] && [ -n "$safe_id" ]; then
   subagent_dir="${transcript_path%.jsonl}/subagents"
   if [ -d "$subagent_dir" ]; then
-    subagent_tokens=$(cat "$subagent_dir"/agent-*.jsonl 2>/dev/null \
-      | jq -r 'select(.type == "assistant") | "\(.message.id) \(.message.usage.input_tokens // 0) \(.message.usage.output_tokens // 0)"' 2>/dev/null \
-      | awk '{usage[$1]=$2" "$3} END {for(id in usage){split(usage[id],a);s+=a[1]+a[2]} print s+0}')
-    subagent_tokens=${subagent_tokens:-0}
-    [ "$subagent_tokens" -gt 0 ] 2>/dev/null && total_tokens=$((total_tokens + subagent_tokens))
+    subagent_cache="/tmp/${SUBAGENT_STATE_PREFIX}-${safe_id}"
+    # Fingerprint: size:mtime:path per file, joined into one line
+    if stat -c '%s' /dev/null >/dev/null 2>&1; then
+      fingerprint=$(stat -c '%s:%Y:%n' "$subagent_dir"/agent-*.jsonl 2>/dev/null | tr '\n' '|')
+    else
+      fingerprint=$(stat -f '%z:%m:%N' "$subagent_dir"/agent-*.jsonl 2>/dev/null | tr '\n' '|')
+    fi
+    if [ -n "$fingerprint" ]; then
+      cached_fp=""
+      [ -f "$subagent_cache" ] && cached_fp=$(head -1 "$subagent_cache")
+      if [ "$fingerprint" = "$cached_fp" ]; then
+        subagent_tokens=$(tail -1 "$subagent_cache")
+      else
+        subagent_tokens=$(cat "$subagent_dir"/agent-*.jsonl 2>/dev/null \
+          | jq -r 'select(.type == "assistant") | "\(.message.id) \(.message.usage.input_tokens // 0) \(.message.usage.output_tokens // 0)"' 2>/dev/null \
+          | awk '{usage[$1]=$2" "$3} END {for(id in usage){split(usage[id],a);s+=a[1]+a[2]} print s+0}')
+        subagent_tokens=${subagent_tokens:-0}
+        printf '%s\n%s\n' "$fingerprint" "$subagent_tokens" > "$subagent_cache"
+      fi
+    fi
   fi
 fi
+subagent_tokens=${subagent_tokens:-0}
+[ "$subagent_tokens" -gt 0 ] 2>/dev/null && total_tokens=$((total_tokens + subagent_tokens))
 
 if [ "$duration_ms" -gt 0 ]; then
   tpm=$(( (total_tokens * 60000) / duration_ms ))

--- a/test/context.bats
+++ b/test/context.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+
+load 'helpers'
+
+# ─── Context bar ───
+
+@test "bar: 0% shows empty" {
+  run run_sl "Opus 4.6" 0
+  [[ "$(plain)" == *"░░░░░ 0%"* ]]
+}
+
+@test "bar: 19% shows empty (below 20% threshold)" {
+  run run_sl "Opus 4.6" 19
+  [[ "$(plain)" == *"░░░░░ 19%"* ]]
+}
+
+@test "bar: 20% shows one filled" {
+  run run_sl "Opus 4.6" 20
+  [[ "$(plain)" == *"▓░░░░ 20%"* ]]
+}
+
+@test "bar: 40% shows two filled" {
+  run run_sl "Opus 4.6" 40
+  [[ "$(plain)" == *"▓▓░░░ 40%"* ]]
+}
+
+@test "bar: 60% shows three filled" {
+  run run_sl "Opus 4.6" 60
+  [[ "$(plain)" == *"▓▓▓░░ 60%"* ]]
+}
+
+@test "bar: 80% shows four filled" {
+  run run_sl "Opus 4.6" 80
+  [[ "$(plain)" == *"▓▓▓▓░ 80%"* ]]
+}
+
+@test "bar: 95% shows full (special case)" {
+  run run_sl "Opus 4.6" 95
+  [[ "$(plain)" == *"▓▓▓▓▓ 95%"* ]]
+}
+
+@test "bar: 100% shows full" {
+  run run_sl "Opus 4.6" 100
+  [[ "$(plain)" == *"▓▓▓▓▓ 100%"* ]]
+}
+
+# ─── Context color tiers ───
+
+@test "color: dim below 35%" {
+  run run_sl "Opus 4.6" 34
+  # \033[38;5;247m = dim gray
+  [[ "$output" == *$'\033[38;5;247m'"▓"* ]]
+}
+
+@test "color: yellow-green at 35%" {
+  run run_sl "Opus 4.6" 35
+  # \033[38;5;148m = yellow-green
+  [[ "$output" == *$'\033[38;5;148m'"▓"* ]]
+}
+
+@test "color: yellow at 50%" {
+  run run_sl "Opus 4.6" 50
+  # \033[93m = yellow
+  [[ "$output" == *$'\033[93m'"▓"* ]]
+}
+
+@test "color: orange at 75%" {
+  run run_sl "Opus 4.6" 75
+  # \033[38;5;208m = orange
+  [[ "$output" == *$'\033[38;5;208m'"▓"* ]]
+}

--- a/test/edge.bats
+++ b/test/edge.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+load 'helpers'
+
+# ─── Bad input ───
+
+@test "bad input: empty JSON object still produces output" {
+  run sh -c 'echo "{}" | sh "$1"' _ "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" == *"✦ unknown"* ]]
+  [[ "$(plain)" == *"░░░░░ 0%"* ]]
+}
+
+@test "bad input: non-JSON input produces safe defaults" {
+  run sh -c 'echo "not json" | sh "$1"' _ "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" == *"✦ unknown"* ]]
+  [[ "$(plain)" == *"░░░░░ 0%"* ]]
+}
+
+@test "bad input: missing model field shows unknown" {
+  local json
+  json=$(jq -n '{
+    cwd: "",
+    session_id: "test",
+    transcript_path: "",
+    context_window: { used_percentage: 25, total_input_tokens: 0, total_output_tokens: 0 },
+    cost: { total_duration_ms: 0 }
+  }')
+  run sh -c 'printf "%s" "$1" | sh "$2"' _ "$json" "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" == *"✦ unknown"* ]]
+}

--- a/test/git.bats
+++ b/test/git.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+
+load 'helpers'
+
+# ─── Git integration ───
+
+@test "git: shows branch name" {
+  TEST_GIT_REPO=$(mktemp -d)
+  git -C "$TEST_GIT_REPO" init -b test-branch >/dev/null 2>&1
+  git -C "$TEST_GIT_REPO" -c user.name=test -c user.email=test@test commit --allow-empty -m "init" >/dev/null 2>&1
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "$TEST_GIT_REPO"
+  [[ "$(plain)" == *"⌥ test-branch"* ]]
+}
+
+@test "git: shows diff stats for tracked changes" {
+  TEST_GIT_REPO=$(mktemp -d)
+  git -C "$TEST_GIT_REPO" init -b main >/dev/null 2>&1
+  git -C "$TEST_GIT_REPO" -c user.name=test -c user.email=test@test commit --allow-empty -m "init" >/dev/null 2>&1
+  printf 'line1\nline2\nline3\n' > "$TEST_GIT_REPO/file.txt"
+  git -C "$TEST_GIT_REPO" add file.txt
+  git -C "$TEST_GIT_REPO" -c user.name=test -c user.email=test@test commit -m "add file" >/dev/null 2>&1
+  printf 'changed\nline2\nline3\nnew\n' > "$TEST_GIT_REPO/file.txt"
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "$TEST_GIT_REPO"
+  # 1 insertion (+new line, +changed), 1 deletion (-line1)
+  [[ "$(plain)" == *"+2"* ]]
+  [[ "$(plain)" == *"-1"* ]]
+}
+
+@test "git: counts untracked file lines" {
+  TEST_GIT_REPO=$(mktemp -d)
+  git -C "$TEST_GIT_REPO" init -b main >/dev/null 2>&1
+  git -C "$TEST_GIT_REPO" -c user.name=test -c user.email=test@test commit --allow-empty -m "init" >/dev/null 2>&1
+  printf 'a\nb\nc\n' > "$TEST_GIT_REPO/untracked.txt"
+  # Must run from repo dir: git ls-files outputs relative paths that grep reads from cwd
+  cd "$TEST_GIT_REPO"
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "$TEST_GIT_REPO"
+  [[ "$(plain)" == *"+3"* ]]
+}
+
+@test "git: detached HEAD shows short SHA" {
+  TEST_GIT_REPO=$(mktemp -d)
+  git -C "$TEST_GIT_REPO" init -b main >/dev/null 2>&1
+  git -C "$TEST_GIT_REPO" -c user.name=test -c user.email=test@test commit --allow-empty -m "init" >/dev/null 2>&1
+  local sha
+  sha=$(git -C "$TEST_GIT_REPO" rev-parse --short HEAD)
+  git -C "$TEST_GIT_REPO" checkout --detach HEAD >/dev/null 2>&1
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "$TEST_GIT_REPO"
+  [[ "$(plain)" == *"⌥ ${sha}"* ]]
+}
+
+@test "git: empty repo shows branch name" {
+  TEST_GIT_REPO=$(mktemp -d)
+  git -C "$TEST_GIT_REPO" init -b main >/dev/null 2>&1
+  # No commits -- empty repo
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "$TEST_GIT_REPO"
+  [[ "$(plain)" == *"⌥ main"* ]]
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+SCRIPT="$BATS_TEST_DIRNAME/../statusline.sh"
+
+setup() {
+  TEST_SID="bats-$$-${BATS_TEST_NUMBER}"
+  cleanup_state "$TEST_SID"
+  cleanup_state "${TEST_SID}-a"
+  cleanup_state "${TEST_SID}-b"
+}
+
+teardown() {
+  cleanup_state "$TEST_SID"
+  cleanup_state "${TEST_SID}-a"
+  cleanup_state "${TEST_SID}-b"
+  [ -n "${TEST_GIT_REPO:-}" ] && rm -rf "$TEST_GIT_REPO" || true
+}
+
+cleanup_state() {
+  local sid="$1"
+  rm -f "/tmp/claude-code-statusline-model-${sid}"
+  rm -f "/tmp/claude-code-statusline-tpm-${sid}"
+  rm -f "/tmp/claude-code-statusline-subagent-${sid}"
+}
+
+# Build JSON input using jq for proper escaping
+# Args: model used session_id duration_ms total_in total_out cwd transcript_path
+make_json() {
+  local model="${1:-Opus 4.6}"
+  local used="${2:-25}"
+  local session_id="${3:-$TEST_SID}"
+  local duration_ms="${4:-60000}"
+  local total_in="${5:-5000}"
+  local total_out="${6:-3000}"
+  local cwd="${7:-}"
+  local transcript_path="${8:-}"
+  jq -n \
+    --arg cwd "$cwd" \
+    --arg sid "$session_id" \
+    --arg tp "$transcript_path" \
+    --argjson used "$used" \
+    --arg model "$model" \
+    --argjson tin "$total_in" \
+    --argjson tout "$total_out" \
+    --argjson dur "$duration_ms" \
+    '{
+      cwd: $cwd,
+      session_id: $sid,
+      transcript_path: $tp,
+      context_window: { used_percentage: $used, total_input_tokens: $tin, total_output_tokens: $tout },
+      model: { display_name: $model },
+      cost: { total_duration_ms: $dur }
+    }'
+}
+
+# Run the script, capturing output for assertions via `run`
+run_sl() {
+  make_json "$@" | sh "$SCRIPT"
+}
+
+# Set up cache state without capturing output
+invoke() {
+  make_json "$@" | sh "$SCRIPT" > /dev/null
+}
+
+# Strip ANSI escape codes from $output
+plain() {
+  printf '%s' "$output" | sed $'s/\033\[[0-9;]*m//g'
+}
+
+# Read model cache file for a session
+cached_model() {
+  head -1 "/tmp/claude-code-statusline-model-${1:-$TEST_SID}"
+}
+
+cached_duration() {
+  tail -1 "/tmp/claude-code-statusline-model-${1:-$TEST_SID}"
+}

--- a/test/model.bats
+++ b/test/model.bats
@@ -1,0 +1,134 @@
+#!/usr/bin/env bats
+
+load 'helpers'
+
+# ─── Model validation ───
+
+@test "model: accepts 'Opus 4.6'" {
+  run run_sl "Opus 4.6"
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" == *"✦ Opus 4.6"* ]]
+}
+
+@test "model: accepts 'Sonnet 4.6'" {
+  run run_sl "Sonnet 4.6"
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" == *"✦ Sonnet 4.6"* ]]
+}
+
+@test "model: accepts 'Haiku 4.5'" {
+  run run_sl "Haiku 4.5"
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" == *"✦ Haiku 4.5"* ]]
+}
+
+@test "model: strips parenthetical suffix 'Opus 4.6 (1M context)'" {
+  run run_sl "Opus 4.6 (1M context)"
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" == *"✦ Opus 4.6"* ]]
+}
+
+@test "model: rejects garbled 'Op.6'" {
+  run run_sl "Op.6"
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" == *"✦ unknown"* ]]
+}
+
+@test "model: rejects truncated 'Son'" {
+  run run_sl "Son"
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" == *"✦ unknown"* ]]
+}
+
+@test "model: rejects lowercase 'opus 4.6'" {
+  run run_sl "opus 4.6"
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" == *"✦ unknown"* ]]
+}
+
+@test "model: rejects trailing text 'Opus 4.6 extra'" {
+  run run_sl "Opus 4.6 extra"
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" == *"✦ unknown"* ]]
+}
+
+@test "model: rejects multi-word name 'Sonnet Max 4.6'" {
+  run run_sl "Sonnet Max 4.6"
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" == *"✦ unknown"* ]]
+}
+
+@test "model: passes through 'unknown' as-is" {
+  run run_sl "unknown"
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" == *"✦ unknown"* ]]
+}
+
+# ─── Model cache ───
+
+@test "cache: first invocation initializes cache file" {
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000
+  [ -f "/tmp/claude-code-statusline-model-${TEST_SID}" ]
+  [ "$(cached_model)" = "Opus 4.6" ]
+  [ "$(cached_duration)" = "60000" ]
+}
+
+@test "cache: unknown model does not create cache file" {
+  run run_sl "unknown" 25 "$TEST_SID" 60000
+  [ ! -f "/tmp/claude-code-statusline-model-${TEST_SID}" ]
+}
+
+@test "cache: preserved when duration unchanged (no new activity)" {
+  invoke "Opus 4.6" 25 "$TEST_SID" 60000
+  # Same duration, CC now reports Sonnet -- cache should win
+  run run_sl "Sonnet 4.6" 25 "$TEST_SID" 60000
+  [[ "$(plain)" == *"✦ Opus 4.6"* ]]
+  [ "$(cached_model)" = "Opus 4.6" ]
+}
+
+@test "cache: updated when duration increases with known model" {
+  invoke "Opus 4.6" 25 "$TEST_SID" 60000
+  run run_sl "Sonnet 4.6" 25 "$TEST_SID" 120000
+  [[ "$(plain)" == *"✦ Sonnet 4.6"* ]]
+  [ "$(cached_model)" = "Sonnet 4.6" ]
+  [ "$(cached_duration)" = "120000" ]
+}
+
+@test "cache: NOT updated when duration increases with garbled model" {
+  invoke "Opus 4.6" 25 "$TEST_SID" 60000
+  # Garbled name fails validation -> treated as unknown -> cache preserved
+  run run_sl "Op.6" 25 "$TEST_SID" 120000
+  [[ "$(plain)" == *"✦ Opus 4.6"* ]]
+  [ "$(cached_model)" = "Opus 4.6" ]
+}
+
+@test "cache: session restart (duration decreases) resets cache" {
+  invoke "Opus 4.6" 25 "$TEST_SID" 120000
+  run run_sl "Sonnet 4.6" 25 "$TEST_SID" 5000
+  [[ "$(plain)" == *"✦ Sonnet 4.6"* ]]
+  [ "$(cached_model)" = "Sonnet 4.6" ]
+  [ "$(cached_duration)" = "5000" ]
+}
+
+@test "cache: session restart with unknown model shows unknown" {
+  invoke "Opus 4.6" 25 "$TEST_SID" 120000
+  run run_sl "unknown" 25 "$TEST_SID" 5000
+  # Restart detected but model is unknown -- display shows unknown
+  # (old cache is from previous session lifecycle, not reused)
+  [[ "$(plain)" == *"✦ unknown"* ]]
+}
+
+@test "cache: sessions are fully isolated" {
+  invoke "Opus 4.6" 25 "${TEST_SID}-a" 60000
+  invoke "Sonnet 4.6" 25 "${TEST_SID}-b" 60000
+  [ "$(cached_model "${TEST_SID}-a")" = "Opus 4.6" ]
+  [ "$(cached_model "${TEST_SID}-b")" = "Sonnet 4.6" ]
+}
+
+@test "cache: empty session_id bypasses caching" {
+  run run_sl "Opus 4.6" 25 "" 60000
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" == *"✦ Opus 4.6"* ]]
+  # No cache file for empty session (safe_id is empty, caching is skipped)
+  [ ! -f "/tmp/claude-code-statusline-model-" ]
+}

--- a/test/subagent.bats
+++ b/test/subagent.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+load 'helpers'
+
+# ─── Subagent tokens ───
+
+@test "subagent: tokens added to total" {
+  local transcript_dir
+  transcript_dir=$(mktemp -d)/transcript
+  mkdir -p "${transcript_dir}/subagents"
+  # Create a minimal subagent JSONL with one assistant message
+  printf '{"type":"assistant","message":{"id":"msg_1","usage":{"input_tokens":100,"output_tokens":50}}}\n' \
+    > "${transcript_dir}/subagents/agent-1.jsonl"
+  local tp="${transcript_dir}.jsonl"
+  touch "$tp"
+  # 8000 base tokens + 150 subagent = 8150, in 60s = 8150 tpm
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "$tp"
+  [[ "$(plain)" == *"8.1k tpm"* ]]
+  rm -rf "$(dirname "$transcript_dir")"
+}
+
+@test "subagent: cache hit on unchanged files" {
+  local transcript_dir
+  transcript_dir=$(mktemp -d)/transcript
+  mkdir -p "${transcript_dir}/subagents"
+  printf '{"type":"assistant","message":{"id":"msg_1","usage":{"input_tokens":100,"output_tokens":50}}}\n' \
+    > "${transcript_dir}/subagents/agent-1.jsonl"
+  local tp="${transcript_dir}.jsonl"
+  touch "$tp"
+  # First call: parses and caches
+  invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "$tp"
+  local cache="/tmp/claude-code-statusline-subagent-${TEST_SID}"
+  [ -f "$cache" ]
+  local first_fp
+  first_fp=$(head -1 "$cache")
+  # Second call: same files, should use cache (fingerprint unchanged)
+  invoke "Opus 4.6" 25 "$TEST_SID" 120000 6000 4000 "" "$tp"
+  [ "$(head -1 "$cache")" = "$first_fp" ]
+  [ "$(tail -1 "$cache")" = "150" ]
+  rm -rf "$(dirname "$transcript_dir")"
+}

--- a/test/tpm.bats
+++ b/test/tpm.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+
+load 'helpers'
+
+# ─── TPM calculation ───
+
+@test "tpm: not shown when duration is zero" {
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 0 0 0
+  [[ "$(plain)" != *"tpm"* ]]
+}
+
+@test "tpm: not shown when tokens are zero" {
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 0 0
+  [[ "$(plain)" != *"tpm"* ]]
+}
+
+@test "tpm: shows raw number below 1k" {
+  # 500 in + 0 out in 60s = 500 tpm
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 500 0
+  [[ "$(plain)" == *"⚡500 tpm"* ]]
+}
+
+@test "tpm: shows N.Nk for 1000-9999" {
+  # 3000 tokens in 60s = 3000 tpm
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 2000 1000
+  [[ "$(plain)" == *"3.0k tpm"* ]]
+}
+
+@test "tpm: shows Nk for 10000+" {
+  # 20000 tokens in 60s = 20000 tpm
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 12000 8000
+  [[ "$(plain)" == *"20k tpm"* ]]
+}
+
+# ─── TPM bolt colors ───
+
+@test "bolt: no color below 1000 tpm" {
+  # 500 tpm -> plain bolt
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 500 0
+  # Should NOT have any color code immediately before the bolt
+  [[ "$output" != *$'\033[93m'"⚡"* ]]
+  [[ "$output" != *$'\033[38;5;209m'"⚡"* ]]
+  [[ "$output" != *$'\033[91m'"⚡"* ]]
+  [[ "$output" != *$'\033[38;5;57m'"⚡"* ]]
+}
+
+@test "bolt: yellow at 1000 tpm" {
+  # 1000 tokens in 60s = 1000 tpm
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 600 400
+  [[ "$output" == *$'\033[93m'"⚡"* ]]
+}
+
+@test "bolt: orange at 5000 tpm" {
+  # 5000 tokens in 60s = 5000 tpm
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 3000 2000
+  [[ "$output" == *$'\033[38;5;209m'"⚡"* ]]
+}
+
+@test "bolt: red at 10000 tpm" {
+  # 10000 tokens in 60s = 10000 tpm
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 6000 4000
+  [[ "$output" == *$'\033[91m'"⚡"* ]]
+}
+
+@test "bolt: violet at 20000 tpm" {
+  # 20000 tokens in 60s = 20000 tpm
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 12000 8000
+  [[ "$output" == *$'\033[38;5;57m'"⚡"* ]]
+}
+
+# ─── TPM sliding window ───
+
+@test "tpm: first invocation uses full-session average" {
+  # 8000 tokens in 60s = 8000 tpm
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000
+  [[ "$(plain)" == *"8.0k tpm"* ]]
+}
+
+@test "tpm: sliding window overrides average on second call" {
+  # Call 1: 8000 tokens at t=60s
+  invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000
+  # Call 2: 9000 tokens at t=120s -> window: 1000 tok / 60s = 1000 tpm
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 120000 5500 3500
+  [[ "$(plain)" == *"1.0k tpm"* ]]
+}
+
+@test "tpm: session restart clears window" {
+  invoke "Opus 4.6" 25 "$TEST_SID" 120000 50000 30000
+  # Duration goes backward -> restart -> window resets
+  # 1000 tokens in 5s = 12000 tpm
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 5000 600 400
+  [[ "$(plain)" == *"12k tpm"* ]]
+}


### PR DESCRIPTION
## Summary

- Parse subagent JSONL transcripts and include their tokens in the TPM calculation
- Derive subagent file paths from `transcript_path` in the statusline JSON
- Deduplicate by message ID to avoid overcounting streaming chunks
- Cache subagent token totals using file mtime fingerprints to avoid re-parsing on every tick
- Validate model names to filter garbled input from Claude Code
- Add BATS test suite covering context, edge cases, git, model, subagent, and TPM

Closes #1
Closes #7
Closes #9

## Test plan

- [ ] Verify TPM increases when subagents are active
- [ ] Verify no change when session has no subagents
- [ ] Verify graceful fallback when `transcript_path` is missing
- [ ] Verify cache hits on consecutive ticks with no new subagent activity
- [ ] Run `bats test/` and verify all tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subagent token usage is now included in total token and TPM calculations.
  * Model name validation filters garbled input and shows "unknown" for unrecognized names.
  * TPM uses a 5-minute sliding-window calculation that accounts for subagent tokens.

* **Documentation**
  * README updated to reflect subagent token tracking, model validation, and TPM behavior.
  * Added development section with test setup and run instructions.

* **Tests**
  * Comprehensive Bats test suite added covering model validation, TPM, subagents, progress bar, Git info, and integration helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->