### PR TITLE
Use koppa (ϟ) instead of emoji bolt for TPM indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A minimal Claude Code statusline with context usage, branch, model, and diff inf
 | Diff | `+42 -7` | Commit before new work |
 | Model | `✦ Opus 4.6` | Active model |
 | Context | `▓▓░░░ 43%` | Stay under 50% for best results |
-| Throughput | `⚡︎ 1.2k tpm` | How fast you're going |
+| Throughput | `ϟ 1.2k tpm` | How fast you're going |
 
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A minimal Claude Code statusline with context usage, branch, model, and diff inf
 | Diff | `+42 -7` | Commit before new work |
 | Model | `✦ Opus 4.6` | Active model |
 | Context | `▓▓░░░ 43%` | Stay under 50% for best results |
-| Throughput | `ϟ 1.2k tpm` | How fast you're going |
+| Throughput | `⚡︎ 1.2k tpm` | How fast you're going |
 
 
 ## Install

--- a/statusline.sh
+++ b/statusline.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Status line: ⌥ branch  +N -N  ✦ model  ▓▓░░ N%  ⚡︎N tpm
+# Status line: ⌥ branch  +N -N  ✦ model  ▓▓░░ N%  ϟ N tpm
 
 TPM_STATE_PREFIX="claude-code-statusline-tpm"
 TPM_WINDOW_MS=300000  # 5 minutes
@@ -258,15 +258,15 @@ if [ "$tpm" -gt 0 ]; then
     tpm_display="$tpm"
   fi
   if [ "$tpm" -ge 20000 ]; then
-    bolt="\033[38;5;57m⚡︎${dim}"   # deep violet
+    bolt="\033[38;5;57mϟ${dim}"   # deep violet
   elif [ "$tpm" -ge 10000 ]; then
-    bolt="\033[91m⚡︎${dim}"        # red
+    bolt="\033[91mϟ${dim}"        # red
   elif [ "$tpm" -ge 5000 ]; then
-    bolt="\033[38;5;209m⚡︎${dim}"  # orange
+    bolt="\033[38;5;209mϟ${dim}"  # orange
   elif [ "$tpm" -ge 1000 ]; then
-    bolt="\033[93m⚡︎${dim}"        # yellow
+    bolt="\033[93mϟ${dim}"        # yellow
   else
-    bolt="⚡︎"
+    bolt="ϟ"
   fi
-  printf "${sep}${dim}${bolt}%s tpm${reset}" "$tpm_display"
+  printf "${sep}${dim}${bolt} %s tpm${reset}" "$tpm_display"
 fi

--- a/statusline.sh
+++ b/statusline.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Status line: ⌥ branch  +N -N  ✦ model  ▓▓░░ N%  ⚡N tpm
+# Status line: ⌥ branch  +N -N  ✦ model  ▓▓░░ N%  ⚡︎N tpm
 
 TPM_STATE_PREFIX="claude-code-statusline-tpm"
 TPM_WINDOW_MS=300000  # 5 minutes
@@ -258,15 +258,15 @@ if [ "$tpm" -gt 0 ]; then
     tpm_display="$tpm"
   fi
   if [ "$tpm" -ge 20000 ]; then
-    bolt="\033[38;5;57m⚡${dim}"   # deep violet
+    bolt="\033[38;5;57m⚡︎${dim}"   # deep violet
   elif [ "$tpm" -ge 10000 ]; then
-    bolt="\033[91m⚡${dim}"        # red
+    bolt="\033[91m⚡︎${dim}"        # red
   elif [ "$tpm" -ge 5000 ]; then
-    bolt="\033[38;5;209m⚡${dim}"  # orange
+    bolt="\033[38;5;209m⚡︎${dim}"  # orange
   elif [ "$tpm" -ge 1000 ]; then
-    bolt="\033[93m⚡${dim}"        # yellow
+    bolt="\033[93m⚡︎${dim}"        # yellow
   else
-    bolt="⚡"
+    bolt="⚡︎"
   fi
   printf "${sep}${dim}${bolt}%s tpm${reset}" "$tpm_display"
 fi

--- a/test/tpm.bats
+++ b/test/tpm.bats
@@ -17,7 +17,7 @@ load 'helpers'
 @test "tpm: shows raw number below 1k" {
   # 500 in + 0 out in 60s = 500 tpm
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 500 0
-  [[ "$(plain)" == *"⚡︎500 tpm"* ]]
+  [[ "$(plain)" == *"ϟ 500 tpm"* ]]
 }
 
 @test "tpm: shows N.Nk for 1000-9999" {
@@ -38,34 +38,34 @@ load 'helpers'
   # 500 tpm -> plain bolt
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 500 0
   # Should NOT have any color code immediately before the bolt
-  [[ "$output" != *$'\033[93m'"⚡︎"* ]]
-  [[ "$output" != *$'\033[38;5;209m'"⚡︎"* ]]
-  [[ "$output" != *$'\033[91m'"⚡︎"* ]]
-  [[ "$output" != *$'\033[38;5;57m'"⚡︎"* ]]
+  [[ "$output" != *$'\033[93m'"ϟ"* ]]
+  [[ "$output" != *$'\033[38;5;209m'"ϟ"* ]]
+  [[ "$output" != *$'\033[91m'"ϟ"* ]]
+  [[ "$output" != *$'\033[38;5;57m'"ϟ"* ]]
 }
 
 @test "bolt: yellow at 1000 tpm" {
   # 1000 tokens in 60s = 1000 tpm
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 600 400
-  [[ "$output" == *$'\033[93m'"⚡︎"* ]]
+  [[ "$output" == *$'\033[93m'"ϟ"* ]]
 }
 
 @test "bolt: orange at 5000 tpm" {
   # 5000 tokens in 60s = 5000 tpm
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 3000 2000
-  [[ "$output" == *$'\033[38;5;209m'"⚡︎"* ]]
+  [[ "$output" == *$'\033[38;5;209m'"ϟ"* ]]
 }
 
 @test "bolt: red at 10000 tpm" {
   # 10000 tokens in 60s = 10000 tpm
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 6000 4000
-  [[ "$output" == *$'\033[91m'"⚡︎"* ]]
+  [[ "$output" == *$'\033[91m'"ϟ"* ]]
 }
 
 @test "bolt: violet at 20000 tpm" {
   # 20000 tokens in 60s = 20000 tpm
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 12000 8000
-  [[ "$output" == *$'\033[38;5;57m'"⚡︎"* ]]
+  [[ "$output" == *$'\033[38;5;57m'"ϟ"* ]]
 }
 
 # ─── TPM sliding window ───

--- a/test/tpm.bats
+++ b/test/tpm.bats
@@ -17,7 +17,7 @@ load 'helpers'
 @test "tpm: shows raw number below 1k" {
   # 500 in + 0 out in 60s = 500 tpm
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 500 0
-  [[ "$(plain)" == *"⚡500 tpm"* ]]
+  [[ "$(plain)" == *"⚡︎500 tpm"* ]]
 }
 
 @test "tpm: shows N.Nk for 1000-9999" {
@@ -38,34 +38,34 @@ load 'helpers'
   # 500 tpm -> plain bolt
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 500 0
   # Should NOT have any color code immediately before the bolt
-  [[ "$output" != *$'\033[93m'"⚡"* ]]
-  [[ "$output" != *$'\033[38;5;209m'"⚡"* ]]
-  [[ "$output" != *$'\033[91m'"⚡"* ]]
-  [[ "$output" != *$'\033[38;5;57m'"⚡"* ]]
+  [[ "$output" != *$'\033[93m'"⚡︎"* ]]
+  [[ "$output" != *$'\033[38;5;209m'"⚡︎"* ]]
+  [[ "$output" != *$'\033[91m'"⚡︎"* ]]
+  [[ "$output" != *$'\033[38;5;57m'"⚡︎"* ]]
 }
 
 @test "bolt: yellow at 1000 tpm" {
   # 1000 tokens in 60s = 1000 tpm
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 600 400
-  [[ "$output" == *$'\033[93m'"⚡"* ]]
+  [[ "$output" == *$'\033[93m'"⚡︎"* ]]
 }
 
 @test "bolt: orange at 5000 tpm" {
   # 5000 tokens in 60s = 5000 tpm
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 3000 2000
-  [[ "$output" == *$'\033[38;5;209m'"⚡"* ]]
+  [[ "$output" == *$'\033[38;5;209m'"⚡︎"* ]]
 }
 
 @test "bolt: red at 10000 tpm" {
   # 10000 tokens in 60s = 10000 tpm
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 6000 4000
-  [[ "$output" == *$'\033[91m'"⚡"* ]]
+  [[ "$output" == *$'\033[91m'"⚡︎"* ]]
 }
 
 @test "bolt: violet at 20000 tpm" {
   # 20000 tokens in 60s = 20000 tpm
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 12000 8000
-  [[ "$output" == *$'\033[38;5;57m'"⚡"* ]]
+  [[ "$output" == *$'\033[38;5;57m'"⚡︎"* ]]
 }
 
 # ─── TPM sliding window ───


### PR DESCRIPTION
## Summary
- Replace `⚡` (U+26A1) with `ϟ` (U+03DE, koppa) for the TPM bolt icon to avoid emoji rendering issues across terminals and fonts
- Koppa is a Greek letter that looks like a lightning bolt but is always rendered as a text glyph
- Add space between bolt and TPM value since the old emoji provided its own spacing

Closes #12

## Test plan
- [x] All 54 BATS tests pass
- [x] Verified `ϟ` renders as a text glyph across terminals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the TPM status indicator character in the status line.
  * Adjusted spacing between the indicator and numeric TPM value for improved visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->