### PR TITLE
Add rate limit usage tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.3.0
+
+### Added
+
+- Rate limit usage tracking for 5-hour and 7-day windows, shown on a second line
+  - Smart visibility: shown on first session invocation, when on pace to hit the limit, or when usage exceeds 75%
+  - Color-coded usage tiers (dim/yellow/orange/red) with rounded countdown to reset
+
 ## 1.2.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![POSIX shell](https://img.shields.io/badge/Shell-POSIX-green.svg)](statusline.sh)
 [![macOS / Linux](https://img.shields.io/badge/macOS_|_Linux-compatible-lightgrey.svg)]()
 
-A minimal Claude Code statusline with context usage, branch, model, and diff info. Built for Max subscribers who don't hit their session limits.
+A minimal Claude Code statusline showing branch, diff, model, context, throughput, and rate limit usage.
 
 <img width="685" height="100" alt="Screenshot" src="https://github.com/user-attachments/assets/5ce0a134-6b07-4754-8b9c-dca3e8fc6574" />
 
@@ -16,15 +16,16 @@ A minimal Claude Code statusline with context usage, branch, model, and diff inf
 - **Terminal-first** – plain text symbols, no emojis
 
 
-## Indicators
+## What it shows
 
-| Indicator | Example | Why |
-|-----------|---------|-----|
-| Branch | `⌥ main` | Active branch |
-| Diff | `+42 -7` | Commit before new work |
-| Model | `✦ Opus 4.6` | Active model |
-| Context | `▓▓░░░ 43%` | Stay under 50% for best results |
-| Throughput | `ϟ 1.2k tpm` | How fast you're going |
+- **Branch** – current git branch
+- **Diff** – uncommitted additions and deletions
+- **Model** – active Claude model
+- **Context** – usage bar and percentage. Grey under 35%, yellow-green under 50%, yellow under 75%, orange above. Start a new conversation before 50% for best results
+- **Throughput** – tokens per minute. Grey under 1k, yellow at 1k, orange at 5k, red at 10k, violet at 20k
+- **Rate limits** – 5-hour and weekly usage with countdown. Grey under 50%, yellow at 50%, orange at 75%, red at 90%. Shown on first use of each session, when on pace to hit the limit, and when over 75%. If hidden, you're within a comfortable pace
+
+Indicators without data are hidden rather than shown empty.
 
 
 ## Install
@@ -53,22 +54,20 @@ Or clone and symlink: `git clone https://github.com/levibe/claude-code-statuslin
 
 ## Requirements
 
-- [`jq`](https://jqlang.github.io/jq/) — JSON parsing
-- `git` — branch and diff information
+- [`jq`](https://jqlang.github.io/jq/) – JSON parsing
+- `git` – branch and diff information
 
 `brew install jq git` or `apt install jq git`
 
 
 ## Notes
 
-- Context bar color shifts from grey to yellow-green to yellow to orange as usage increases
-- Tokens per minute bolt gains color as you speed up
 - Tracks text diffs, untracked files, and binary file changes (binary files count as +1 added or -1 removed)
-- TPM uses a 5-minute sliding window and includes subagent token usage
-- Fixes model name bleeding across sessions ([CC bug](https://github.com/anthropics/claude-code/issues/19570))
 - Caps line counting at 10k to avoid slowdowns on large diffs
-- Works in empty repos, detached HEAD, and normal branches
+- TPM uses a 5-minute sliding window and includes subagent token usage
+- Shows short SHA on detached HEAD; falls back to symbolic ref in empty repos
 - Uses `--no-optional-locks` on all git calls to prevent lock contention
+- Fixes model name bleeding across sessions ([CC bug](https://github.com/anthropics/claude-code/issues/19570))
 - Validates model names to filter garbled input from Claude Code
 
 

--- a/statusline.sh
+++ b/statusline.sh
@@ -98,9 +98,11 @@ total_in=${total_in:-0}; total_out=${total_out:-0}; duration_ms=${duration_ms:-0
 rl_5h_pct=${rl_5h_pct:-}; rl_5h_reset=${rl_5h_reset:-}
 rl_7d_pct=${rl_7d_pct:-}; rl_7d_reset=${rl_7d_reset:-}
 
-# Validate resets_at fields are numeric
+# Validate numeric fields
 case "$rl_5h_reset" in ""|*[!0-9]*) rl_5h_reset="" ;; esac
 case "$rl_7d_reset" in ""|*[!0-9]*) rl_7d_reset="" ;; esac
+case "$rl_5h_pct" in ""|*[!0-9.]*|*.*.*) rl_5h_pct="" ;; esac
+case "$rl_7d_pct" in ""|*[!0-9.]*|*.*.*) rl_7d_pct="" ;; esac
 
 # Validate model name: must match "Name N.N" pattern (e.g. "Opus 4.6", "Sonnet 4.6", "Haiku 4.5")
 # Garbled names from Claude Code (e.g. "Op.6") are treated as unknown so they don't pollute the cache

--- a/statusline.sh
+++ b/statusline.sh
@@ -334,13 +334,16 @@ if [ -n "$rl_5h_pct" ] || [ -n "$rl_7d_pct" ]; then
   _now=$(date +%s)
 
   # First invocation of this session (show for USAGE_FIRST_WINDOW_S seconds)?
+  # State file creation is deferred until a window actually renders, so partial
+  # data (e.g. pct without reset) does not burn the first-usage grace period.
   first_usage=0
+  usage_state_exists=0
   if [ -n "$safe_id" ]; then
     usage_state="/tmp/${USAGE_STATE_PREFIX}-${safe_id}"
     if [ ! -f "$usage_state" ]; then
-      printf '%s\n' "$_now" > "$usage_state"
       first_usage=1
     else
+      usage_state_exists=1
       usage_created=$(head -1 "$usage_state" 2>/dev/null)
       case "$usage_created" in *[!0-9]*|"") usage_created="" ;; esac
       if [ -n "$usage_created" ] && [ "$((_now - usage_created))" -lt "$USAGE_FIRST_WINDOW_S" ] 2>/dev/null; then
@@ -369,6 +372,12 @@ if [ -n "$rl_5h_pct" ] || [ -n "$rl_7d_pct" ]; then
       rl_7d_pct_int=$(echo "$result_7d" | sed -n '1p')
       remaining_7d=$(echo "$result_7d" | sed -n '2p')
     fi
+  fi
+
+  # Create state file only once a window has actually rendered
+  if [ "$usage_state_exists" -eq 0 ] && [ -n "$safe_id" ] \
+     && { [ "$show_5h" -eq 1 ] || [ "$show_7d" -eq 1 ]; }; then
+    printf '%s\n' "$_now" > "$usage_state"
   fi
 fi
 

--- a/statusline.sh
+++ b/statusline.sh
@@ -418,7 +418,7 @@ if [ "$show_5h" -eq 1 ] || [ "$show_7d" -eq 1 ]; then
     rl_5h_color=$(usage_color "$rl_5h_pct_int")
     rl_5h_vcolor=$(usage_value_color "$rl_5h_pct_int")
     countdown_5h=$(fmt_countdown "$remaining_5h")
-    printf "${rl_5h_color}5h ${rl_5h_vcolor}%s%%${reset} \033[2;38;5;246m%s${reset}" "$rl_5h_pct_int" "$countdown_5h"
+    printf "${rl_5h_color}5h ${rl_5h_vcolor}%s%%${reset} \033[2;38;5;249m%s${reset}" "$rl_5h_pct_int" "$countdown_5h"
   fi
 
   if [ "$show_7d" -eq 1 ]; then
@@ -426,7 +426,7 @@ if [ "$show_5h" -eq 1 ] || [ "$show_7d" -eq 1 ]; then
     rl_7d_color=$(usage_color "$rl_7d_pct_int")
     rl_7d_vcolor=$(usage_value_color "$rl_7d_pct_int")
     countdown_7d=$(fmt_countdown "$remaining_7d")
-    printf "${rl_7d_color}7d ${rl_7d_vcolor}%s%%${reset} \033[2;38;5;246m%s${reset}" "$rl_7d_pct_int" "$countdown_7d"
+    printf "${rl_7d_color}7d ${rl_7d_vcolor}%s%%${reset} \033[2;38;5;249m%s${reset}" "$rl_7d_pct_int" "$countdown_7d"
   fi
 fi
 

--- a/statusline.sh
+++ b/statusline.sh
@@ -36,6 +36,43 @@ usage_value_color() {
   fi
 }
 
+# should_show_window pct_raw reset_at window_seconds first_usage
+# Prints two lines (pct_int, remaining) if the window should be shown,
+# or nothing (empty output) otherwise.  Uses _now from caller scope.
+should_show_window() {
+  _pct=$1; _reset=$2; _window=$3; _first=$4
+  _pct_int=${_pct%%.*}
+  _pct_int=${_pct_int:-0}
+  _remaining=$((_reset - _now))
+  [ "$_remaining" -lt 0 ] 2>/dev/null && _remaining=0
+
+  case "$_pct" in
+    *.*)
+      _i=${_pct%%.*}; _f=${_pct#*.}; _d=${_f%"${_f#?}"}
+      _pct_x10=$(( (${_i:-0} * 10) + ${_d:-0} ))
+      ;;
+    *)
+      _pct_x10=$(( ${_pct:-0} * 10 ))
+      ;;
+  esac
+
+  _show=0
+  if [ "$_first" -eq 1 ] || [ "$_pct_int" -ge 75 ]; then
+    _show=1
+  else
+    _elapsed=$((_window - _remaining))
+    if [ "$_elapsed" -le 0 ]; then
+      _show=1
+    elif [ "$((_pct_x10 * _window))" -ge "$((1000 * _elapsed))" ]; then
+      _show=1
+    fi
+  fi
+
+  if [ "$_show" -eq 1 ]; then
+    printf '%s\n%s\n' "$_pct_int" "$_remaining"
+  fi
+}
+
 input=$(cat)
 
 # Single jq call to extract all fields (floor handles potential floats)
@@ -48,9 +85,9 @@ eval "$(echo "$input" | jq -r '
   "total_in=\(.context_window.total_input_tokens // 0 | floor | @sh)",
   "total_out=\(.context_window.total_output_tokens // 0 | floor | @sh)",
   "duration_ms=\(.cost.total_duration_ms // 0 | floor | @sh)",
-  "rl_5h_pct=\(.rate_limits.five_hour.used_percentage // "" | if type == "number" then floor else . end | @sh)",
+  "rl_5h_pct=\(.rate_limits.five_hour.used_percentage // "" | @sh)",
   "rl_5h_reset=\(.rate_limits.five_hour.resets_at // "" | @sh)",
-  "rl_7d_pct=\(.rate_limits.seven_day.used_percentage // "" | if type == "number" then floor else . end | @sh)",
+  "rl_7d_pct=\(.rate_limits.seven_day.used_percentage // "" | @sh)",
   "rl_7d_reset=\(.rate_limits.seven_day.resets_at // "" | @sh)"
 ')"
 
@@ -62,8 +99,8 @@ rl_5h_pct=${rl_5h_pct:-}; rl_5h_reset=${rl_5h_reset:-}
 rl_7d_pct=${rl_7d_pct:-}; rl_7d_reset=${rl_7d_reset:-}
 
 # Validate resets_at fields are numeric
-case "$rl_5h_reset" in *[!0-9]*) rl_5h_reset="" ;; esac
-case "$rl_7d_reset" in *[!0-9]*) rl_7d_reset="" ;; esac
+case "$rl_5h_reset" in ""|*[!0-9]*) rl_5h_reset="" ;; esac
+case "$rl_7d_reset" in ""|*[!0-9]*) rl_7d_reset="" ;; esac
 
 # Validate model name: must match "Name N.N" pattern (e.g. "Opus 4.6", "Sonnet 4.6", "Haiku 4.5")
 # Garbled names from Claude Code (e.g. "Op.6") are treated as unknown so they don't pollute the cache
@@ -294,19 +331,19 @@ remaining_5h=0
 remaining_7d=0
 
 if [ -n "$rl_5h_pct" ] || [ -n "$rl_7d_pct" ]; then
-  now=$(date +%s)
+  _now=$(date +%s)
 
   # First invocation of this session (show for USAGE_FIRST_WINDOW_S seconds)?
   first_usage=0
   if [ -n "$safe_id" ]; then
     usage_state="/tmp/${USAGE_STATE_PREFIX}-${safe_id}"
     if [ ! -f "$usage_state" ]; then
-      printf '%s\n' "$now" > "$usage_state"
+      printf '%s\n' "$_now" > "$usage_state"
       first_usage=1
     else
       usage_created=$(head -1 "$usage_state" 2>/dev/null)
       case "$usage_created" in *[!0-9]*|"") usage_created="" ;; esac
-      if [ -n "$usage_created" ] && [ "$((now - usage_created))" -lt "$USAGE_FIRST_WINDOW_S" ] 2>/dev/null; then
+      if [ -n "$usage_created" ] && [ "$((_now - usage_created))" -lt "$USAGE_FIRST_WINDOW_S" ] 2>/dev/null; then
         first_usage=1
       fi
     fi
@@ -316,61 +353,21 @@ if [ -n "$rl_5h_pct" ] || [ -n "$rl_7d_pct" ]; then
 
   # 5h window (18000s total)
   if [ -n "$rl_5h_pct" ] && [ -n "$rl_5h_reset" ]; then
-    rl_5h_pct_int=${rl_5h_pct%%.*}
-    rl_5h_pct_int=${rl_5h_pct_int:-0}
-    remaining_5h=$((rl_5h_reset - now))
-    [ "$remaining_5h" -lt 0 ] 2>/dev/null && remaining_5h=0
-
-    # Scale percentage x10 for precise pace comparison (e.g., 49.9 -> 499)
-    case "$rl_5h_pct" in
-      *.*)
-        _i=${rl_5h_pct%%.*}; _f=${rl_5h_pct#*.}; _d=${_f%"${_f#?}"}
-        rl_5h_pct_x10=$(( (${_i:-0} * 10) + ${_d:-0} ))
-        ;;
-      *)
-        rl_5h_pct_x10=$(( ${rl_5h_pct:-0} * 10 ))
-        ;;
-    esac
-
-    if [ "$first_usage" -eq 1 ] || [ "$rl_5h_pct_int" -ge 75 ]; then
+    result_5h=$(should_show_window "$rl_5h_pct" "$rl_5h_reset" 18000 "$first_usage")
+    if [ -n "$result_5h" ]; then
       show_5h=1
-    else
-      elapsed_5h=$((18000 - remaining_5h))
-      if [ "$elapsed_5h" -le 0 ]; then
-        show_5h=1  # window just started
-      elif [ "$((rl_5h_pct_x10 * 18000))" -ge "$((1000 * elapsed_5h))" ]; then
-        show_5h=1  # on pace to hit limit
-      fi
+      rl_5h_pct_int=$(echo "$result_5h" | sed -n '1p')
+      remaining_5h=$(echo "$result_5h" | sed -n '2p')
     fi
   fi
 
   # 7d window (604800s total)
   if [ -n "$rl_7d_pct" ] && [ -n "$rl_7d_reset" ]; then
-    rl_7d_pct_int=${rl_7d_pct%%.*}
-    rl_7d_pct_int=${rl_7d_pct_int:-0}
-    remaining_7d=$((rl_7d_reset - now))
-    [ "$remaining_7d" -lt 0 ] 2>/dev/null && remaining_7d=0
-
-    # Scale percentage x10 for precise pace comparison
-    case "$rl_7d_pct" in
-      *.*)
-        _i=${rl_7d_pct%%.*}; _f=${rl_7d_pct#*.}; _d=${_f%"${_f#?}"}
-        rl_7d_pct_x10=$(( (${_i:-0} * 10) + ${_d:-0} ))
-        ;;
-      *)
-        rl_7d_pct_x10=$(( ${rl_7d_pct:-0} * 10 ))
-        ;;
-    esac
-
-    if [ "$first_usage" -eq 1 ] || [ "$rl_7d_pct_int" -ge 75 ]; then
+    result_7d=$(should_show_window "$rl_7d_pct" "$rl_7d_reset" 604800 "$first_usage")
+    if [ -n "$result_7d" ]; then
       show_7d=1
-    else
-      elapsed_7d=$((604800 - remaining_7d))
-      if [ "$elapsed_7d" -le 0 ]; then
-        show_7d=1
-      elif [ "$((rl_7d_pct_x10 * 604800))" -ge "$((1000 * elapsed_7d))" ]; then
-        show_7d=1
-      fi
+      rl_7d_pct_int=$(echo "$result_7d" | sed -n '1p')
+      remaining_7d=$(echo "$result_7d" | sed -n '2p')
     fi
   fi
 fi
@@ -407,18 +404,16 @@ fi
 
 if [ "$show_5h" -eq 1 ] || [ "$show_7d" -eq 1 ]; then
   printf '\n'
-  line2_started=0
 
   if [ "$show_5h" -eq 1 ]; then
     rl_5h_color=$(usage_color "$rl_5h_pct_int")
     rl_5h_vcolor=$(usage_value_color "$rl_5h_pct_int")
     countdown_5h=$(fmt_countdown "$remaining_5h")
     printf "${rl_5h_color}5h ${rl_5h_vcolor}%s%%${reset} \033[2;38;5;246m%s${reset}" "$rl_5h_pct_int" "$countdown_5h"
-    line2_started=1
   fi
 
   if [ "$show_7d" -eq 1 ]; then
-    [ "$line2_started" -eq 1 ] && printf "$sep"
+    [ "$show_5h" -eq 1 ] && printf "$sep"
     rl_7d_color=$(usage_color "$rl_7d_pct_int")
     rl_7d_vcolor=$(usage_value_color "$rl_7d_pct_int")
     countdown_7d=$(fmt_countdown "$remaining_7d")

--- a/statusline.sh
+++ b/statusline.sh
@@ -1,10 +1,33 @@
 #!/bin/sh
-# Status line: ⌥ branch  +N -N  ✦ model  ▓▓░░ N%  ϟ N tpm
+# Line 1: ⌥ branch  +N -N  ✦ model  ▓▓░░ N%  ϟ N tpm
+# Line 2: 5h N% XhYm  7d N% XdYh   (shown when on pace / ≥75%)
 
 TPM_STATE_PREFIX="claude-code-statusline-tpm"
 TPM_WINDOW_MS=300000  # 5 minutes
 MODEL_STATE_PREFIX="claude-code-statusline-model"
 SUBAGENT_STATE_PREFIX="claude-code-statusline-subagent"
+USAGE_STATE_PREFIX="claude-code-statusline-usage"
+
+# Helpers for rate limit display
+fmt_countdown() {
+  if [ "$1" -ge 86400 ] 2>/dev/null; then
+    printf '%dd %dh' "$(($1 / 86400))" "$(($1 % 86400 / 3600))"
+  elif [ "$1" -ge 3600 ] 2>/dev/null; then
+    printf '%dh %dm' "$(($1 / 3600))" "$(($1 % 3600 / 60))"
+  elif [ "$1" -ge 60 ] 2>/dev/null; then
+    printf '%dm' "$(($1 / 60))"
+  else
+    printf '%ds' "$1"
+  fi
+}
+
+usage_color() {
+  if [ "$1" -ge 90 ] 2>/dev/null; then printf '%s' '\033[91m'
+  elif [ "$1" -ge 75 ] 2>/dev/null; then printf '%s' '\033[38;5;208m'
+  elif [ "$1" -ge 50 ] 2>/dev/null; then printf '%s' '\033[93m'
+  else printf '%s' '\033[38;5;247m'
+  fi
+}
 
 input=$(cat)
 
@@ -17,13 +40,23 @@ eval "$(echo "$input" | jq -r '
   "model=\(.model.display_name // "unknown" | sub(" *\\(.*\\)"; "") | @sh)",
   "total_in=\(.context_window.total_input_tokens // 0 | floor | @sh)",
   "total_out=\(.context_window.total_output_tokens // 0 | floor | @sh)",
-  "duration_ms=\(.cost.total_duration_ms // 0 | floor | @sh)"
+  "duration_ms=\(.cost.total_duration_ms // 0 | floor | @sh)",
+  "rl_5h_pct=\(.rate_limits.five_hour.used_percentage // "" | if type == "number" then floor else . end | @sh)",
+  "rl_5h_reset=\(.rate_limits.five_hour.resets_at // "" | @sh)",
+  "rl_7d_pct=\(.rate_limits.seven_day.used_percentage // "" | if type == "number" then floor else . end | @sh)",
+  "rl_7d_reset=\(.rate_limits.seven_day.resets_at // "" | @sh)"
 ')"
 
 # Defaults if jq fails or fields are missing
 cwd=${cwd:-}; session_id=${session_id:-}; transcript_path=${transcript_path:-}
 used=${used:-0}; model=${model:-unknown}
 total_in=${total_in:-0}; total_out=${total_out:-0}; duration_ms=${duration_ms:-0}
+rl_5h_pct=${rl_5h_pct:-}; rl_5h_reset=${rl_5h_reset:-}
+rl_7d_pct=${rl_7d_pct:-}; rl_7d_reset=${rl_7d_reset:-}
+
+# Validate resets_at fields are numeric
+case "$rl_5h_reset" in *[!0-9]*) rl_5h_reset="" ;; esac
+case "$rl_7d_reset" in *[!0-9]*) rl_7d_reset="" ;; esac
 
 # Validate model name: must match "Name N.N" pattern (e.g. "Opus 4.6", "Sonnet 4.6", "Haiku 4.5")
 # Garbled names from Claude Code (e.g. "Op.6") are treated as unknown so they don't pollute the cache
@@ -245,6 +278,68 @@ if [ -n "$cwd" ]; then
   fi
 fi
 
+# Rate limit visibility (each window shown independently)
+show_5h=0
+show_7d=0
+rl_5h_pct_int=0
+rl_7d_pct_int=0
+remaining_5h=0
+remaining_7d=0
+
+if [ -n "$rl_5h_pct" ] || [ -n "$rl_7d_pct" ]; then
+  now=$(date +%s)
+
+  # First invocation of this session?
+  first_usage=0
+  if [ -n "$safe_id" ]; then
+    usage_state="/tmp/${USAGE_STATE_PREFIX}-${safe_id}"
+    if [ ! -f "$usage_state" ]; then
+      first_usage=1
+      : > "$usage_state"
+    fi
+  fi
+
+  # 5h window (18000s total)
+  if [ -n "$rl_5h_pct" ] && [ -n "$rl_5h_reset" ]; then
+    rl_5h_pct_int=${rl_5h_pct%%.*}
+    rl_5h_pct_int=${rl_5h_pct_int:-0}
+    remaining_5h=$((rl_5h_reset - now))
+    [ "$remaining_5h" -lt 0 ] 2>/dev/null && remaining_5h=0
+
+    if [ "$first_usage" -eq 1 ] || [ "$rl_5h_pct_int" -ge 75 ]; then
+      show_5h=1
+    else
+      elapsed_5h=$((18000 - remaining_5h))
+      if [ "$elapsed_5h" -le 0 ]; then
+        show_5h=1  # window just started
+      elif [ "$((rl_5h_pct_int * 18000))" -ge "$((100 * elapsed_5h))" ]; then
+        show_5h=1  # on pace to hit limit
+      fi
+    fi
+  fi
+
+  # 7d window (604800s total)
+  if [ -n "$rl_7d_pct" ] && [ -n "$rl_7d_reset" ]; then
+    rl_7d_pct_int=${rl_7d_pct%%.*}
+    rl_7d_pct_int=${rl_7d_pct_int:-0}
+    remaining_7d=$((rl_7d_reset - now))
+    [ "$remaining_7d" -lt 0 ] 2>/dev/null && remaining_7d=0
+
+    if [ "$first_usage" -eq 1 ] || [ "$rl_7d_pct_int" -ge 75 ]; then
+      show_7d=1
+    else
+      elapsed_7d=$((604800 - remaining_7d))
+      if [ "$elapsed_7d" -le 0 ]; then
+        show_7d=1
+      elif [ "$((rl_7d_pct_int * 604800))" -ge "$((100 * elapsed_7d))" ]; then
+        show_7d=1
+      fi
+    fi
+  fi
+fi
+
+# ─── Line 1: branch, diff, model, context, tpm ───
+
 printf "\033[36m⌥ %s${reset}" "$branch"
 printf "%b" "$diff_stat"
 printf "${sep}\033[38;5;252m✦ %s${reset}" "$model"
@@ -270,3 +365,25 @@ if [ "$tpm" -gt 0 ]; then
   fi
   printf "${sep}${dim}${bolt} %s tpm${reset}" "$tpm_display"
 fi
+
+# ─── Line 2: rate limit usage ───
+
+if [ "$show_5h" -eq 1 ] || [ "$show_7d" -eq 1 ]; then
+  printf '\n'
+  line2_started=0
+
+  if [ "$show_5h" -eq 1 ]; then
+    rl_5h_color=$(usage_color "$rl_5h_pct_int")
+    countdown_5h=$(fmt_countdown "$remaining_5h")
+    printf "${rl_5h_color}5h %s%%${reset} \033[2;38;5;246m%s${reset}" "$rl_5h_pct_int" "$countdown_5h"
+    line2_started=1
+  fi
+
+  if [ "$show_7d" -eq 1 ]; then
+    [ "$line2_started" -eq 1 ] && printf "$sep"
+    rl_7d_color=$(usage_color "$rl_7d_pct_int")
+    countdown_7d=$(fmt_countdown "$remaining_7d")
+    printf "${rl_7d_color}7d %s%%${reset} \033[2;38;5;246m%s${reset}" "$rl_7d_pct_int" "$countdown_7d"
+  fi
+fi
+

--- a/statusline.sh
+++ b/statusline.sh
@@ -7,6 +7,7 @@ TPM_WINDOW_MS=300000  # 5 minutes
 MODEL_STATE_PREFIX="claude-code-statusline-model"
 SUBAGENT_STATE_PREFIX="claude-code-statusline-subagent"
 USAGE_STATE_PREFIX="claude-code-statusline-usage"
+USAGE_FIRST_WINDOW_S=5   # seconds to show rate limits on first invocation
 
 # Helpers for rate limit display
 fmt_countdown() {
@@ -26,6 +27,12 @@ usage_color() {
   elif [ "$1" -ge 75 ] 2>/dev/null; then printf '%s' '\033[38;5;208m'
   elif [ "$1" -ge 50 ] 2>/dev/null; then printf '%s' '\033[93m'
   else printf '%s' '\033[38;5;247m'
+  fi
+}
+
+usage_value_color() {
+  if [ "$1" -ge 50 ] 2>/dev/null; then usage_color "$1"
+  else printf '%s' '\033[97m'
   fi
 }
 
@@ -289,14 +296,22 @@ remaining_7d=0
 if [ -n "$rl_5h_pct" ] || [ -n "$rl_7d_pct" ]; then
   now=$(date +%s)
 
-  # First invocation of this session?
+  # First invocation of this session (show for USAGE_FIRST_WINDOW_S seconds)?
   first_usage=0
   if [ -n "$safe_id" ]; then
     usage_state="/tmp/${USAGE_STATE_PREFIX}-${safe_id}"
     if [ ! -f "$usage_state" ]; then
+      printf '%s\n' "$now" > "$usage_state"
       first_usage=1
-      : > "$usage_state"
+    else
+      usage_created=$(head -1 "$usage_state" 2>/dev/null)
+      case "$usage_created" in *[!0-9]*|"") usage_created="" ;; esac
+      if [ -n "$usage_created" ] && [ "$((now - usage_created))" -lt "$USAGE_FIRST_WINDOW_S" ] 2>/dev/null; then
+        first_usage=1
+      fi
     fi
+  else
+    first_usage=1
   fi
 
   # 5h window (18000s total)
@@ -306,13 +321,24 @@ if [ -n "$rl_5h_pct" ] || [ -n "$rl_7d_pct" ]; then
     remaining_5h=$((rl_5h_reset - now))
     [ "$remaining_5h" -lt 0 ] 2>/dev/null && remaining_5h=0
 
+    # Scale percentage x10 for precise pace comparison (e.g., 49.9 -> 499)
+    case "$rl_5h_pct" in
+      *.*)
+        _i=${rl_5h_pct%%.*}; _f=${rl_5h_pct#*.}; _d=${_f%"${_f#?}"}
+        rl_5h_pct_x10=$(( (${_i:-0} * 10) + ${_d:-0} ))
+        ;;
+      *)
+        rl_5h_pct_x10=$(( ${rl_5h_pct:-0} * 10 ))
+        ;;
+    esac
+
     if [ "$first_usage" -eq 1 ] || [ "$rl_5h_pct_int" -ge 75 ]; then
       show_5h=1
     else
       elapsed_5h=$((18000 - remaining_5h))
       if [ "$elapsed_5h" -le 0 ]; then
         show_5h=1  # window just started
-      elif [ "$((rl_5h_pct_int * 18000))" -ge "$((100 * elapsed_5h))" ]; then
+      elif [ "$((rl_5h_pct_x10 * 18000))" -ge "$((1000 * elapsed_5h))" ]; then
         show_5h=1  # on pace to hit limit
       fi
     fi
@@ -325,13 +351,24 @@ if [ -n "$rl_5h_pct" ] || [ -n "$rl_7d_pct" ]; then
     remaining_7d=$((rl_7d_reset - now))
     [ "$remaining_7d" -lt 0 ] 2>/dev/null && remaining_7d=0
 
+    # Scale percentage x10 for precise pace comparison
+    case "$rl_7d_pct" in
+      *.*)
+        _i=${rl_7d_pct%%.*}; _f=${rl_7d_pct#*.}; _d=${_f%"${_f#?}"}
+        rl_7d_pct_x10=$(( (${_i:-0} * 10) + ${_d:-0} ))
+        ;;
+      *)
+        rl_7d_pct_x10=$(( ${rl_7d_pct:-0} * 10 ))
+        ;;
+    esac
+
     if [ "$first_usage" -eq 1 ] || [ "$rl_7d_pct_int" -ge 75 ]; then
       show_7d=1
     else
       elapsed_7d=$((604800 - remaining_7d))
       if [ "$elapsed_7d" -le 0 ]; then
         show_7d=1
-      elif [ "$((rl_7d_pct_int * 604800))" -ge "$((100 * elapsed_7d))" ]; then
+      elif [ "$((rl_7d_pct_x10 * 604800))" -ge "$((1000 * elapsed_7d))" ]; then
         show_7d=1
       fi
     fi
@@ -374,16 +411,18 @@ if [ "$show_5h" -eq 1 ] || [ "$show_7d" -eq 1 ]; then
 
   if [ "$show_5h" -eq 1 ]; then
     rl_5h_color=$(usage_color "$rl_5h_pct_int")
+    rl_5h_vcolor=$(usage_value_color "$rl_5h_pct_int")
     countdown_5h=$(fmt_countdown "$remaining_5h")
-    printf "${rl_5h_color}5h %s%%${reset} \033[2;38;5;246m%s${reset}" "$rl_5h_pct_int" "$countdown_5h"
+    printf "${rl_5h_color}5h ${rl_5h_vcolor}%s%%${reset} \033[2;38;5;246m%s${reset}" "$rl_5h_pct_int" "$countdown_5h"
     line2_started=1
   fi
 
   if [ "$show_7d" -eq 1 ]; then
     [ "$line2_started" -eq 1 ] && printf "$sep"
     rl_7d_color=$(usage_color "$rl_7d_pct_int")
+    rl_7d_vcolor=$(usage_value_color "$rl_7d_pct_int")
     countdown_7d=$(fmt_countdown "$remaining_7d")
-    printf "${rl_7d_color}7d %s%%${reset} \033[2;38;5;246m%s${reset}" "$rl_7d_pct_int" "$countdown_7d"
+    printf "${rl_7d_color}7d ${rl_7d_vcolor}%s%%${reset} \033[2;38;5;246m%s${reset}" "$rl_7d_pct_int" "$countdown_7d"
   fi
 fi
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -21,10 +21,12 @@ cleanup_state() {
   rm -f "/tmp/claude-code-statusline-model-${sid}"
   rm -f "/tmp/claude-code-statusline-tpm-${sid}"
   rm -f "/tmp/claude-code-statusline-subagent-${sid}"
+  rm -f "/tmp/claude-code-statusline-usage-${sid}"
 }
 
 # Build JSON input using jq for proper escaping
 # Args: model used session_id duration_ms total_in total_out cwd transcript_path
+#       [rl_5h_pct rl_5h_reset rl_7d_pct rl_7d_reset]
 make_json() {
   local model="${1:-Opus 4.6}"
   local used="${2:-25}"
@@ -34,7 +36,12 @@ make_json() {
   local total_out="${6:-3000}"
   local cwd="${7:-}"
   local transcript_path="${8:-}"
-  jq -n \
+  local rl_5h_pct="${9:-}"
+  local rl_5h_reset="${10:-}"
+  local rl_7d_pct="${11:-}"
+  local rl_7d_reset="${12:-}"
+  local base
+  base=$(jq -n \
     --arg cwd "$cwd" \
     --arg sid "$session_id" \
     --arg tp "$transcript_path" \
@@ -50,7 +57,22 @@ make_json() {
       context_window: { used_percentage: $used, total_input_tokens: $tin, total_output_tokens: $tout },
       model: { display_name: $model },
       cost: { total_duration_ms: $dur }
-    }'
+    }')
+  if [ -n "$rl_5h_pct" ] || [ -n "$rl_7d_pct" ]; then
+    local rl_args=()
+    local rl_filter="."
+    if [ -n "$rl_5h_pct" ] && [ -n "$rl_5h_reset" ]; then
+      rl_args+=(--argjson rl5p "$rl_5h_pct" --argjson rl5r "$rl_5h_reset")
+      rl_filter="$rl_filter | .rate_limits.five_hour = {used_percentage: \$rl5p, resets_at: \$rl5r}"
+    fi
+    if [ -n "$rl_7d_pct" ] && [ -n "$rl_7d_reset" ]; then
+      rl_args+=(--argjson rl7p "$rl_7d_pct" --argjson rl7r "$rl_7d_reset")
+      rl_filter="$rl_filter | .rate_limits.seven_day = {used_percentage: \$rl7p, resets_at: \$rl7r}"
+    fi
+    echo "$base" | jq "${rl_args[@]}" "$rl_filter"
+  else
+    echo "$base"
+  fi
 }
 
 # Run the script, capturing output for assertions via `run`

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -58,16 +58,18 @@ make_json() {
       model: { display_name: $model },
       cost: { total_duration_ms: $dur }
     }')
-  if [ -n "$rl_5h_pct" ] || [ -n "$rl_7d_pct" ]; then
+  if [ -n "$rl_5h_pct" ] || [ -n "$rl_5h_reset" ] || [ -n "$rl_7d_pct" ] || [ -n "$rl_7d_reset" ]; then
     local rl_args=()
     local rl_filter="."
-    if [ -n "$rl_5h_pct" ] && [ -n "$rl_5h_reset" ]; then
-      rl_args+=(--argjson rl5p "$rl_5h_pct" --argjson rl5r "$rl_5h_reset")
-      rl_filter="$rl_filter | .rate_limits.five_hour = {used_percentage: \$rl5p, resets_at: \$rl5r}"
+    if [ -n "$rl_5h_pct" ] || [ -n "$rl_5h_reset" ]; then
+      rl_filter="$rl_filter | .rate_limits.five_hour = {}"
+      [ -n "$rl_5h_pct" ] && rl_args+=(--argjson rl5p "$rl_5h_pct") && rl_filter="$rl_filter | .rate_limits.five_hour.used_percentage = \$rl5p"
+      [ -n "$rl_5h_reset" ] && rl_args+=(--argjson rl5r "$rl_5h_reset") && rl_filter="$rl_filter | .rate_limits.five_hour.resets_at = \$rl5r"
     fi
-    if [ -n "$rl_7d_pct" ] && [ -n "$rl_7d_reset" ]; then
-      rl_args+=(--argjson rl7p "$rl_7d_pct" --argjson rl7r "$rl_7d_reset")
-      rl_filter="$rl_filter | .rate_limits.seven_day = {used_percentage: \$rl7p, resets_at: \$rl7r}"
+    if [ -n "$rl_7d_pct" ] || [ -n "$rl_7d_reset" ]; then
+      rl_filter="$rl_filter | .rate_limits.seven_day = {}"
+      [ -n "$rl_7d_pct" ] && rl_args+=(--argjson rl7p "$rl_7d_pct") && rl_filter="$rl_filter | .rate_limits.seven_day.used_percentage = \$rl7p"
+      [ -n "$rl_7d_reset" ] && rl_args+=(--argjson rl7r "$rl_7d_reset") && rl_filter="$rl_filter | .rate_limits.seven_day.resets_at = \$rl7r"
     fi
     echo "$base" | jq "${rl_args[@]}" "$rl_filter"
   else

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -17,7 +17,8 @@ teardown() {
 }
 
 cleanup_state() {
-  local sid="$1"
+  local sid
+  sid=$(printf '%s' "$1" | tr -dc 'a-zA-Z0-9_-')
   rm -f "/tmp/claude-code-statusline-model-${sid}"
   rm -f "/tmp/claude-code-statusline-tpm-${sid}"
   rm -f "/tmp/claude-code-statusline-subagent-${sid}"

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -98,3 +98,8 @@ cached_model() {
 cached_duration() {
   tail -1 "/tmp/claude-code-statusline-model-${1:-$TEST_SID}"
 }
+
+# Expire the first-usage display window for a session
+expire_first_usage() {
+  printf '%s\n' "0" > "/tmp/claude-code-statusline-usage-${1:-$TEST_SID}"
+}

--- a/test/usage.bats
+++ b/test/usage.bats
@@ -67,8 +67,8 @@ load 'helpers'
 
 @test "usage: countdown shows hours and minutes" {
   now=$(date +%s)
-  # 3 hours 30 minutes = 12600s
-  reset=$((now + 12600))
+  # 3 hours 30 minutes = 12600s (+2s buffer for timing)
+  reset=$((now + 12602))
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 80 "$reset" "" ""
   [[ "$(plain)" == *"3h 30m"* ]]
 }
@@ -113,8 +113,9 @@ load 'helpers'
   now=$(date +%s)
   reset=$((now + 3600))
   # Empty session_id means no pace state file, treated as first invocation
-  run run_sl "Opus 4.6" 25 "" 60000 5000 3000 "" "" 80 "$reset" "" ""
-  [[ "$(plain)" == *"5h 80%"* ]]
+  # Use 60% (under-pace) to verify the empty-session fallback shows it anyway
+  run run_sl "Opus 4.6" 25 "" 60000 5000 3000 "" "" 60 "$reset" "" ""
+  [[ "$(plain)" == *"5h 60%"* ]]
 }
 
 # ─── Color tiers ───
@@ -123,28 +124,28 @@ load 'helpers'
   now=$(date +%s)
   reset=$((now + 3600))
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 49 "$reset" "" ""
-  [[ "$output" == *$'\033[38;5;247m'"5h 49%"* ]]
+  [[ "$output" == *$'\033[38;5;247m'"5h "$'\033[97m'"49%"* ]]
 }
 
 @test "usage color: yellow at 50%" {
   now=$(date +%s)
   reset=$((now + 3600))
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 50 "$reset" "" ""
-  [[ "$output" == *$'\033[93m'"5h 50%"* ]]
+  [[ "$output" == *$'\033[93m'"5h "$'\033[93m'"50%"* ]]
 }
 
 @test "usage color: orange at 75%" {
   now=$(date +%s)
   reset=$((now + 3600))
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 75 "$reset" "" ""
-  [[ "$output" == *$'\033[38;5;208m'"5h 75%"* ]]
+  [[ "$output" == *$'\033[38;5;208m'"5h "$'\033[38;5;208m'"75%"* ]]
 }
 
 @test "usage color: red at 90%" {
   now=$(date +%s)
   reset=$((now + 3600))
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 90 "$reset" "" ""
-  [[ "$output" == *$'\033[91m'"5h 90%"* ]]
+  [[ "$output" == *$'\033[91m'"5h "$'\033[91m'"90%"* ]]
 }
 
 # ─── Pace visibility ───
@@ -164,6 +165,7 @@ load 'helpers'
   reset=$((now + 9000))
   # First invocation (creates state file)
   invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
+  expire_first_usage
   # Second invocation should apply pace logic -> hidden
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
   [[ "$(plain)" != *"5h "* ]]
@@ -194,6 +196,7 @@ load 'helpers'
   reset_5h=$((now + 9000))
   reset_7d=$((now + 302400))
   invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset_5h" 80 "$reset_7d"
+  expire_first_usage
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset_5h" 80 "$reset_7d"
   plain_out=$(plain)
   [[ "$plain_out" != *"5h "* ]]
@@ -207,4 +210,35 @@ load 'helpers'
   invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 5 "$reset" "" ""
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 5 "$reset" "" ""
   [[ "$(plain)" == *"5h 5%"* ]]
+}
+
+# ─── First-usage window ───
+
+@test "usage: shown within first-usage window on second invocation" {
+  now=$(date +%s)
+  # 30% used with 50% elapsed -> under pace, normally hidden
+  reset=$((now + 9000))
+  invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
+  # Second invocation is immediate (within 5s window) -> should still show
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
+  [[ "$(plain)" == *"5h 30%"* ]]
+}
+
+@test "usage: hidden after first-usage window expires" {
+  now=$(date +%s)
+  reset=$((now + 9000))
+  invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
+  expire_first_usage
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
+  [[ "$(plain)" != *"5h "* ]]
+}
+
+@test "usage: empty state file from old version treated as window expired" {
+  now=$(date +%s)
+  reset=$((now + 9000))
+  # Simulate old-version state file (empty)
+  : > "/tmp/claude-code-statusline-usage-${TEST_SID}"
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
+  # Under pace and window expired -> hidden
+  [[ "$(plain)" != *"5h "* ]]
 }

--- a/test/usage.bats
+++ b/test/usage.bats
@@ -233,6 +233,44 @@ load 'helpers'
   [[ "$(plain)" != *"5h "* ]]
 }
 
+@test "usage: 100% usage displayed correctly" {
+  now=$(date +%s)
+  reset=$((now + 60))
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 100 "$reset" "" ""
+  [[ "$(plain)" == *"5h 100%"* ]]
+}
+
+@test "usage: pace check uses decimal precision (49.9% over pace, 49% would not be)" {
+  now=$(date +%s)
+  # 5h window = 18000s. At 49.9% with 8950s remaining (elapsed = 9050s):
+  # Pace threshold = elapsed/window = 9050/18000 = 50.3%
+  # 49.9% < 50.3% -> under pace (should be hidden)
+  # But at 49% -> 49% < 50.3% -> also under pace
+  # Use elapsed = 8990s (remaining = 9010s) -> threshold = 8990/18000 = 49.94%
+  # 49.9% >= 49.94%? No (barely under). Use elapsed = 9000s -> threshold = 50%
+  # 49.9% < 50% -> under pace. 49% < 50% -> also under.
+  # Use elapsed = 9010s (remaining = 8990s) -> threshold = 9010/18000 = 50.06%
+  # Need: 49.9% over pace but 49% not. threshold must be between 49% and 49.9%.
+  # threshold = elapsed/18000 -> elapsed = 18000 * 0.495 = 8910 -> remaining = 9090
+  # 49.9% >= 49.5% -> over pace (shown). 49% >= 49.5%? No -> under pace (hidden).
+  reset=$((now + 9090))
+  invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 49.9 "$reset" "" ""
+  expire_first_usage
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 49.9 "$reset" "" ""
+  [[ "$(plain)" == *"5h 49%"* ]]
+}
+
+@test "usage: pace check at 49% (integer) hidden at same elapsed where 49.9% shows" {
+  now=$(date +%s)
+  # Same elapsed as above: remaining = 9090, threshold = 49.5%
+  # 49% < 49.5% -> under pace -> hidden
+  reset=$((now + 9090))
+  invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 49 "$reset" "" ""
+  expire_first_usage
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 49 "$reset" "" ""
+  [[ "$(plain)" != *"5h "* ]]
+}
+
 @test "usage: empty state file from old version treated as window expired" {
   now=$(date +%s)
   reset=$((now + 9000))

--- a/test/usage.bats
+++ b/test/usage.bats
@@ -1,0 +1,210 @@
+#!/usr/bin/env bats
+
+load 'helpers'
+
+# ─── Display ───
+
+@test "usage: no second line when rate_limits absent" {
+  run run_sl "Opus 4.6" 25
+  [[ "$(plain)" != *$'\n'* ]]
+}
+
+@test "usage: shows 5h only when only five_hour present" {
+  now=$(date +%s)
+  reset=$((now + 3600))
+  # 80% used -> always show (>= 75%)
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 80 "$reset" "" ""
+  plain_out=$(plain)
+  [[ "$plain_out" == *"5h 80%"* ]]
+  [[ "$plain_out" != *"7d "* ]]
+}
+
+@test "usage: shows 7d only when only seven_day present" {
+  now=$(date +%s)
+  reset=$((now + 86400))
+  # 80% used -> always show (>= 75%)
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" "" "" 80 "$reset"
+  plain_out=$(plain)
+  [[ "$plain_out" != *"5h "* ]]
+  [[ "$plain_out" == *"7d 80%"* ]]
+}
+
+@test "usage: shows both when both present" {
+  now=$(date +%s)
+  reset_5h=$((now + 3600))
+  reset_7d=$((now + 86400))
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 80 "$reset_5h" 80 "$reset_7d"
+  plain_out=$(plain)
+  [[ "$plain_out" == *"5h 80%"* ]]
+  [[ "$plain_out" == *"7d 80%"* ]]
+}
+
+@test "usage: second line separated by newline" {
+  now=$(date +%s)
+  reset=$((now + 3600))
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 80 "$reset" "" ""
+  line2=$(plain | sed -n '2p')
+  [[ "$line2" == *"5h 80%"* ]]
+}
+
+@test "usage: percentage is floored to integer" {
+  now=$(date +%s)
+  reset=$((now + 3600))
+  # 83.7% -> should display as 83%
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 83.7 "$reset" "" ""
+  [[ "$(plain)" == *"5h 83%"* ]]
+}
+
+# ─── Countdown formatting ───
+
+@test "usage: countdown shows days and hours" {
+  now=$(date +%s)
+  # 2 days 5 hours + buffer = 190830s
+  reset=$((now + 190830))
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" "" "" 80 "$reset"
+  [[ "$(plain)" == *"2d 5h"* ]]
+}
+
+@test "usage: countdown shows hours and minutes" {
+  now=$(date +%s)
+  # 3 hours 30 minutes = 12600s
+  reset=$((now + 12600))
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 80 "$reset" "" ""
+  [[ "$(plain)" == *"3h 30m"* ]]
+}
+
+@test "usage: countdown shows minutes when under an hour" {
+  now=$(date +%s)
+  reset=$((now + 330))
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 80 "$reset" "" ""
+  [[ "$(plain)" == *"5m"* ]]
+}
+
+@test "usage: countdown shows seconds when under a minute" {
+  now=$(date +%s)
+  reset=$((now + 50))
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 80 "$reset" "" ""
+  [[ "$(plain)" == *"49s"* ]] || [[ "$(plain)" == *"50s"* ]]
+}
+
+@test "usage: 0% usage is displayed correctly" {
+  now=$(date +%s)
+  reset=$((now + 9000))
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 0 "$reset" "" ""
+  [[ "$(plain)" == *"5h 0%"* ]]
+}
+
+@test "usage: resets_at in the past clamps to 0s" {
+  now=$(date +%s)
+  reset=$((now - 100))
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 80 "$reset" "" ""
+  [[ "$(plain)" == *"5h 80% 0s"* ]]
+}
+
+@test "usage: non-numeric resets_at is ignored" {
+  # Construct JSON directly to bypass make_json's --argjson validation
+  json='{"cwd":"","session_id":"'"$TEST_SID"'","transcript_path":"","context_window":{"used_percentage":25,"total_input_tokens":5000,"total_output_tokens":3000},"model":{"display_name":"Opus 4.6"},"cost":{"total_duration_ms":60000},"rate_limits":{"five_hour":{"used_percentage":80,"resets_at":"not-a-number"}}}'
+  run sh -c 'echo "$1" | sh "$2"' _ "$json" "$SCRIPT"
+  plain_out=$(printf '%s' "$output" | sed $'s/\033\[[0-9;]*m//g')
+  [[ "$plain_out" != *"5h "* ]]
+}
+
+@test "usage: empty session_id still shows rate limits" {
+  now=$(date +%s)
+  reset=$((now + 3600))
+  # Empty session_id means no pace state file, treated as first invocation
+  run run_sl "Opus 4.6" 25 "" 60000 5000 3000 "" "" 80 "$reset" "" ""
+  [[ "$(plain)" == *"5h 80%"* ]]
+}
+
+# ─── Color tiers ───
+
+@test "usage color: dim below 50%" {
+  now=$(date +%s)
+  reset=$((now + 3600))
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 49 "$reset" "" ""
+  [[ "$output" == *$'\033[38;5;247m'"5h 49%"* ]]
+}
+
+@test "usage color: yellow at 50%" {
+  now=$(date +%s)
+  reset=$((now + 3600))
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 50 "$reset" "" ""
+  [[ "$output" == *$'\033[93m'"5h 50%"* ]]
+}
+
+@test "usage color: orange at 75%" {
+  now=$(date +%s)
+  reset=$((now + 3600))
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 75 "$reset" "" ""
+  [[ "$output" == *$'\033[38;5;208m'"5h 75%"* ]]
+}
+
+@test "usage color: red at 90%" {
+  now=$(date +%s)
+  reset=$((now + 3600))
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 90 "$reset" "" ""
+  [[ "$output" == *$'\033[91m'"5h 90%"* ]]
+}
+
+# ─── Pace visibility ───
+
+@test "usage: first invocation always shows regardless of pace" {
+  now=$(date +%s)
+  # 30% used with 50% elapsed (9000s remaining of 18000s) -> projected 60%, under pace
+  # But first invocation, so should show
+  reset=$((now + 9000))
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
+  [[ "$(plain)" == *"5h 30%"* ]]
+}
+
+@test "usage: hidden when under pace on second invocation" {
+  now=$(date +%s)
+  # 30% used with 50% elapsed (9000s remaining of 18000s) -> projected 60%, under pace
+  reset=$((now + 9000))
+  # First invocation (creates state file)
+  invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
+  # Second invocation should apply pace logic -> hidden
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
+  [[ "$(plain)" != *"5h "* ]]
+}
+
+@test "usage: shown when over pace on second invocation" {
+  now=$(date +%s)
+  # 70% used with 60% elapsed (7200s remaining of 18000s) -> projected 116%, over pace
+  reset=$((now + 7200))
+  invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 70 "$reset" "" ""
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 70 "$reset" "" ""
+  [[ "$(plain)" == *"5h 70%"* ]]
+}
+
+@test "usage: always shown when >= 75% regardless of pace" {
+  now=$(date +%s)
+  # 75% used with only 10% elapsed (16200s remaining of 18000s)
+  reset=$((now + 16200))
+  invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 75 "$reset" "" ""
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 75 "$reset" "" ""
+  [[ "$(plain)" == *"5h 75%"* ]]
+}
+
+@test "usage: 5h and 7d visibility independent" {
+  now=$(date +%s)
+  # 5h: 30% used, 50% elapsed -> under pace, hidden (not first invocation)
+  # 7d: 80% used -> always shown (>= 75%)
+  reset_5h=$((now + 9000))
+  reset_7d=$((now + 302400))
+  invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset_5h" 80 "$reset_7d"
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset_5h" 80 "$reset_7d"
+  plain_out=$(plain)
+  [[ "$plain_out" != *"5h "* ]]
+  [[ "$plain_out" == *"7d 80%"* ]]
+}
+
+@test "usage: shown when window just started (elapsed <= 0)" {
+  now=$(date +%s)
+  # resets_at is nearly a full window away -> elapsed ~0
+  reset=$((now + 18000))
+  invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 5 "$reset" "" ""
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 5 "$reset" "" ""
+  [[ "$(plain)" == *"5h 5%"* ]]
+}

--- a/test/usage.bats
+++ b/test/usage.bats
@@ -271,6 +271,28 @@ load 'helpers'
   [[ "$(plain)" != *"5h "* ]]
 }
 
+@test "usage: partial data (pct without reset) does not burn first-usage window" {
+  now=$(date +%s)
+  reset=$((now + 9000))
+  # First invocation: 5h has pct but no reset -> cannot render, should not create state file
+  invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "" "" ""
+  [[ ! -f "/tmp/claude-code-statusline-usage-${TEST_SID}" ]]
+  # Second invocation: complete data arrives, first-usage still active -> shown
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
+  [[ "$(plain)" == *"5h 30%"* ]]
+}
+
+@test "usage: partial data (reset without pct) does not burn first-usage window" {
+  now=$(date +%s)
+  reset=$((now + 9000))
+  # First invocation: 5h has reset but no pct -> cannot render
+  invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" "" "$reset" "" ""
+  [[ ! -f "/tmp/claude-code-statusline-usage-${TEST_SID}" ]]
+  # Second invocation: complete data -> first-usage still active
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
+  [[ "$(plain)" == *"5h 30%"* ]]
+}
+
 @test "usage: empty state file from old version treated as window expired" {
   now=$(date +%s)
   reset=$((now + 9000))

--- a/test/usage.bats
+++ b/test/usage.bats
@@ -6,6 +6,7 @@ load 'helpers'
 
 @test "usage: no second line when rate_limits absent" {
   run run_sl "Opus 4.6" 25
+  [ "$status" -eq 0 ]
   [[ "$(plain)" != *$'\n'* ]]
 }
 
@@ -14,6 +15,7 @@ load 'helpers'
   reset=$((now + 3600))
   # 80% used -> always show (>= 75%)
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 80 "$reset" "" ""
+  [ "$status" -eq 0 ]
   plain_out=$(plain)
   [[ "$plain_out" == *"5h 80%"* ]]
   [[ "$plain_out" != *"7d "* ]]
@@ -24,6 +26,7 @@ load 'helpers'
   reset=$((now + 86400))
   # 80% used -> always show (>= 75%)
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" "" "" 80 "$reset"
+  [ "$status" -eq 0 ]
   plain_out=$(plain)
   [[ "$plain_out" != *"5h "* ]]
   [[ "$plain_out" == *"7d 80%"* ]]
@@ -34,6 +37,7 @@ load 'helpers'
   reset_5h=$((now + 3600))
   reset_7d=$((now + 86400))
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 80 "$reset_5h" 80 "$reset_7d"
+  [ "$status" -eq 0 ]
   plain_out=$(plain)
   [[ "$plain_out" == *"5h 80%"* ]]
   [[ "$plain_out" == *"7d 80%"* ]]
@@ -43,6 +47,7 @@ load 'helpers'
   now=$(date +%s)
   reset=$((now + 3600))
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 80 "$reset" "" ""
+  [ "$status" -eq 0 ]
   line2=$(plain | sed -n '2p')
   [[ "$line2" == *"5h 80%"* ]]
 }
@@ -52,6 +57,7 @@ load 'helpers'
   reset=$((now + 3600))
   # 83.7% -> should display as 83%
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 83.7 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$(plain)" == *"5h 83%"* ]]
 }
 
@@ -62,6 +68,7 @@ load 'helpers'
   # 2 days 5 hours + buffer = 190830s
   reset=$((now + 190830))
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" "" "" 80 "$reset"
+  [ "$status" -eq 0 ]
   [[ "$(plain)" == *"2d 5h"* ]]
 }
 
@@ -70,6 +77,7 @@ load 'helpers'
   # 3 hours 30 minutes = 12600s (+2s buffer for timing)
   reset=$((now + 12602))
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 80 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$(plain)" == *"3h 30m"* ]]
 }
 
@@ -77,6 +85,7 @@ load 'helpers'
   now=$(date +%s)
   reset=$((now + 330))
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 80 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$(plain)" == *"5m"* ]]
 }
 
@@ -84,6 +93,7 @@ load 'helpers'
   now=$(date +%s)
   reset=$((now + 50))
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 80 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$(plain)" == *"49s"* ]] || [[ "$(plain)" == *"50s"* ]]
 }
 
@@ -91,6 +101,7 @@ load 'helpers'
   now=$(date +%s)
   reset=$((now + 9000))
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 0 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$(plain)" == *"5h 0%"* ]]
 }
 
@@ -98,6 +109,7 @@ load 'helpers'
   now=$(date +%s)
   reset=$((now - 100))
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 80 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$(plain)" == *"5h 80% 0s"* ]]
 }
 
@@ -105,6 +117,7 @@ load 'helpers'
   # Construct JSON directly to bypass make_json's --argjson validation
   json='{"cwd":"","session_id":"'"$TEST_SID"'","transcript_path":"","context_window":{"used_percentage":25,"total_input_tokens":5000,"total_output_tokens":3000},"model":{"display_name":"Opus 4.6"},"cost":{"total_duration_ms":60000},"rate_limits":{"five_hour":{"used_percentage":80,"resets_at":"not-a-number"}}}'
   run sh -c 'echo "$1" | sh "$2"' _ "$json" "$SCRIPT"
+  [ "$status" -eq 0 ]
   plain_out=$(printf '%s' "$output" | sed $'s/\033\[[0-9;]*m//g')
   [[ "$plain_out" != *"5h "* ]]
 }
@@ -115,6 +128,7 @@ load 'helpers'
   # Empty session_id means no pace state file, treated as first invocation
   # Use 60% (under-pace) to verify the empty-session fallback shows it anyway
   run run_sl "Opus 4.6" 25 "" 60000 5000 3000 "" "" 60 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$(plain)" == *"5h 60%"* ]]
 }
 
@@ -124,6 +138,7 @@ load 'helpers'
   now=$(date +%s)
   reset=$((now + 3600))
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 49 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$output" == *$'\033[38;5;247m'"5h "$'\033[97m'"49%"* ]]
 }
 
@@ -131,6 +146,7 @@ load 'helpers'
   now=$(date +%s)
   reset=$((now + 3600))
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 50 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$output" == *$'\033[93m'"5h "$'\033[93m'"50%"* ]]
 }
 
@@ -138,6 +154,7 @@ load 'helpers'
   now=$(date +%s)
   reset=$((now + 3600))
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 75 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$output" == *$'\033[38;5;208m'"5h "$'\033[38;5;208m'"75%"* ]]
 }
 
@@ -145,6 +162,7 @@ load 'helpers'
   now=$(date +%s)
   reset=$((now + 3600))
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 90 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$output" == *$'\033[91m'"5h "$'\033[91m'"90%"* ]]
 }
 
@@ -156,6 +174,7 @@ load 'helpers'
   # But first invocation, so should show
   reset=$((now + 9000))
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$(plain)" == *"5h 30%"* ]]
 }
 
@@ -168,6 +187,7 @@ load 'helpers'
   expire_first_usage
   # Second invocation should apply pace logic -> hidden
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$(plain)" != *"5h "* ]]
 }
 
@@ -177,6 +197,7 @@ load 'helpers'
   reset=$((now + 7200))
   invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 70 "$reset" "" ""
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 70 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$(plain)" == *"5h 70%"* ]]
 }
 
@@ -186,6 +207,7 @@ load 'helpers'
   reset=$((now + 16200))
   invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 75 "$reset" "" ""
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 75 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$(plain)" == *"5h 75%"* ]]
 }
 
@@ -198,6 +220,7 @@ load 'helpers'
   invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset_5h" 80 "$reset_7d"
   expire_first_usage
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset_5h" 80 "$reset_7d"
+  [ "$status" -eq 0 ]
   plain_out=$(plain)
   [[ "$plain_out" != *"5h "* ]]
   [[ "$plain_out" == *"7d 80%"* ]]
@@ -205,11 +228,13 @@ load 'helpers'
 
 @test "usage: shown when window just started (elapsed <= 0)" {
   now=$(date +%s)
-  # resets_at is nearly a full window away -> elapsed ~0
-  reset=$((now + 18000))
-  invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 5 "$reset" "" ""
-  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 5 "$reset" "" ""
-  [[ "$(plain)" == *"5h 5%"* ]]
+  # resets_at beyond a full window -> elapsed < 0
+  reset=$((now + 18005))
+  invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 0 "$reset" "" ""
+  expire_first_usage
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 0 "$reset" "" ""
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" == *"5h 0%"* ]]
 }
 
 # ─── First-usage window ───
@@ -221,6 +246,7 @@ load 'helpers'
   invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
   # Second invocation is immediate (within 5s window) -> should still show
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$(plain)" == *"5h 30%"* ]]
 }
 
@@ -230,6 +256,7 @@ load 'helpers'
   invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
   expire_first_usage
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$(plain)" != *"5h "* ]]
 }
 
@@ -237,6 +264,7 @@ load 'helpers'
   now=$(date +%s)
   reset=$((now + 60))
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 100 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$(plain)" == *"5h 100%"* ]]
 }
 
@@ -257,6 +285,7 @@ load 'helpers'
   invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 49.9 "$reset" "" ""
   expire_first_usage
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 49.9 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$(plain)" == *"5h 49%"* ]]
 }
 
@@ -268,6 +297,7 @@ load 'helpers'
   invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 49 "$reset" "" ""
   expire_first_usage
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 49 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$(plain)" != *"5h "* ]]
 }
 
@@ -279,6 +309,7 @@ load 'helpers'
   [[ ! -f "/tmp/claude-code-statusline-usage-${TEST_SID}" ]]
   # Second invocation: complete data arrives, first-usage still active -> shown
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$(plain)" == *"5h 30%"* ]]
 }
 
@@ -290,6 +321,7 @@ load 'helpers'
   [[ ! -f "/tmp/claude-code-statusline-usage-${TEST_SID}" ]]
   # Second invocation: complete data -> first-usage still active
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
+  [ "$status" -eq 0 ]
   [[ "$(plain)" == *"5h 30%"* ]]
 }
 
@@ -299,6 +331,7 @@ load 'helpers'
   # Simulate old-version state file (empty)
   : > "/tmp/claude-code-statusline-usage-${TEST_SID}"
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" 30 "$reset" "" ""
+  [ "$status" -eq 0 ]
   # Under pace and window expired -> hidden
   [[ "$(plain)" != *"5h "* ]]
 }


### PR DESCRIPTION
## Summary

- Show 5-hour and 7-day rate limit usage on a second status line with color-coded percentages and countdown to reset
- Smart visibility: shown on first session invocation, when on pace to hit the limit, or when usage exceeds 75%
- Update README with new indicator documentation

Closes #13

## Test plan

- [ ] Run `bats test/usage.bats` - all 25 tests pass
- [ ] Verify second line appears on first invocation of a new session
- [ ] Verify second line hides when usage is within a comfortable pace
- [ ] Verify color tiers shift at 50%/75%/90% thresholds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Statusline shows rate-limit usage on a second line with separate 5‑hour and 7‑day segments, color-coded tiers, integer percentages, and rounded countdowns; smart visibility (first invocation, approaching limit, or ≥75%) evaluated per window.

* **Documentation**
  * README updated to describe expanded indicators, visibility rules, countdown semantics, and hiding of indicators without data.

* **Bug Fixes**
  * Malformed/non-numeric reset values are ignored to prevent incorrect countdowns.

* **Tests**
  * Added end-to-end tests for rendering, visibility/pacing, countdown formats, and color thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->