### PR TITLE
Hide branch indicator in non-git directories

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -385,9 +385,12 @@ fi
 
 # ─── Line 1: branch, diff, model, context, tpm ───
 
-printf "\033[36m⌥ %s${reset}" "$branch"
-printf "%b" "$diff_stat"
-printf "${sep}\033[38;5;252m✦ %s${reset}" "$model"
+if [ -n "$branch" ]; then
+  printf "\033[36m⌥ %s${reset}" "$branch"
+  printf "%b" "$diff_stat"
+  printf "%s" "$sep"
+fi
+printf "\033[38;5;252m✦ %s${reset}" "$model"
 printf "${sep}${ctx_color}%s %s%%${reset}" "$bar" "$used"
 if [ "$tpm" -gt 0 ]; then
   if [ "$tpm" -ge 10000 ]; then

--- a/test/git.bats
+++ b/test/git.bats
@@ -55,3 +55,10 @@ load 'helpers'
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "$TEST_GIT_REPO"
   [[ "$(plain)" == *"⌥ main"* ]]
 }
+
+@test "git: no branch indicator outside git repo" {
+  TEST_GIT_REPO=$(mktemp -d)
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "$TEST_GIT_REPO"
+  [[ "$(plain)" != *"⌥"* ]]
+  [[ "$(plain)" == *"✦ Opus 4.6"* ]]
+}


### PR DESCRIPTION
## Summary
- Wrap branch + diff_stat rendering in a `[ -n "$branch" ]` guard so the `⌥` icon is hidden entirely when there's no git repo
- Move the separator inside the conditional so the model indicator starts the line cleanly

Fixes #16

## Test plan
- [x] New test: `git: no branch indicator outside git repo` -- asserts no `⌥` and model still renders
- [x] All 87 existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved statusline rendering to conditionally display the branch indicator only when a git branch is available, eliminating unnecessary empty placeholders and providing a cleaner visual output. Product version identifier continues to display consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->