### PR TITLE
Add decimal point for 10k-100k TPM display

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -393,7 +393,7 @@ fi
 printf "\033[38;5;252m✦ %s${reset}" "$model"
 printf "${sep}${ctx_color}%s %s%%${reset}" "$bar" "$used"
 if [ "$tpm" -gt 0 ]; then
-  if [ "$tpm" -ge 10000 ]; then
+  if [ "$tpm" -ge 100000 ]; then
     tpm_display="$((tpm / 1000))k"
   elif [ "$tpm" -ge 1000 ]; then
     tpm_display="$((tpm / 1000)).$((tpm % 1000 / 100))k"

--- a/test/tpm.bats
+++ b/test/tpm.bats
@@ -26,10 +26,10 @@ load 'helpers'
   [[ "$(plain)" == *"3.0k tpm"* ]]
 }
 
-@test "tpm: shows Nk for 10000+" {
+@test "tpm: shows N.Nk for 10000+" {
   # 20000 tokens in 60s = 20000 tpm
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 12000 8000
-  [[ "$(plain)" == *"20k tpm"* ]]
+  [[ "$(plain)" == *"20.0k tpm"* ]]
 }
 
 # ─── TPM bolt colors ───
@@ -89,5 +89,5 @@ load 'helpers'
   # Duration goes backward -> restart -> window resets
   # 1000 tokens in 5s = 12000 tpm
   run run_sl "Opus 4.6" 25 "$TEST_SID" 5000 600 400
-  [[ "$(plain)" == *"12k tpm"* ]]
+  [[ "$(plain)" == *"12.0k tpm"* ]]
 }

--- a/test/tpm.bats
+++ b/test/tpm.bats
@@ -26,10 +26,13 @@ load 'helpers'
   [[ "$(plain)" == *"3.0k tpm"* ]]
 }
 
-@test "tpm: shows N.Nk for 10000+" {
+@test "tpm: shows N.Nk for 10k-99.9k and integer for 100k+" {
   # 20000 tokens in 60s = 20000 tpm
   run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 12000 8000
   [[ "$(plain)" == *"20.0k tpm"* ]]
+  # 100000 tokens in 60s = 100000 tpm
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 60000 40000
+  [[ "$(plain)" == *"100k tpm"* ]]
 }
 
 # ─── TPM bolt colors ───


### PR DESCRIPTION
## Summary
- Extend the `N.Nk` decimal format from the 1k-10k range to cover 10k-100k as well
- Values 100k+ continue to show without a decimal

Fixes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TPM display formatting updated: abbreviated values now show one decimal place for mid-range thousands (e.g., "20.0k tpm") and the compact "k" representation is applied starting at 100,000 tpm instead of 10,000 tpm.
* **Tests**
  * Updated test expectations to match the new TPM formatting and added coverage for the 100k+ case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->