### PR TITLE
Show 1M context indicator after model name

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -82,6 +82,7 @@ eval "$(echo "$input" | jq -r '
   "transcript_path=\(.transcript_path // "" | @sh)",
   "used=\(.context_window.used_percentage // 0 | floor | @sh)",
   "model=\(.model.display_name // "unknown" | sub(" *\\(.*\\)"; "") | @sh)",
+  "ctx_size=\(.context_window.context_window_size // 0 | floor | @sh)",
   "total_in=\(.context_window.total_input_tokens // 0 | floor | @sh)",
   "total_out=\(.context_window.total_output_tokens // 0 | floor | @sh)",
   "duration_ms=\(.cost.total_duration_ms // 0 | floor | @sh)",
@@ -93,7 +94,7 @@ eval "$(echo "$input" | jq -r '
 
 # Defaults if jq fails or fields are missing
 cwd=${cwd:-}; session_id=${session_id:-}; transcript_path=${transcript_path:-}
-used=${used:-0}; model=${model:-unknown}
+used=${used:-0}; model=${model:-unknown}; ctx_size=${ctx_size:-0}
 total_in=${total_in:-0}; total_out=${total_out:-0}; duration_ms=${duration_ms:-0}
 rl_5h_pct=${rl_5h_pct:-}; rl_5h_reset=${rl_5h_reset:-}
 rl_7d_pct=${rl_7d_pct:-}; rl_7d_reset=${rl_7d_reset:-}
@@ -391,6 +392,9 @@ if [ -n "$branch" ]; then
   printf "%s" "$sep"
 fi
 printf "\033[38;5;252m✦ %s${reset}" "$model"
+if [ "$ctx_size" -ge 1000000 ] 2>/dev/null; then
+  printf " ${dim}1M${reset}"
+fi
 printf "${sep}${ctx_color}%s %s%%${reset}" "$bar" "$used"
 if [ "$tpm" -gt 0 ]; then
   if [ "$tpm" -ge 100000 ]; then

--- a/statusline.sh
+++ b/statusline.sh
@@ -162,9 +162,10 @@ fi
 # Per-session model cache — prevents global model changes in other sessions
 # from affecting this session's display before it has new activity.
 #
-# State file format (2 lines):
+# State file format (3 lines):
 #   line 1: last known model string for this session
-#   line 2: duration_ms at the time that model was recorded
+#   line 2: context_window_size at the time that model was recorded
+#   line 3: duration_ms at the time that model was recorded
 #
 # Update rule: only replace the cached model when duration_ms has increased,
 # meaning this session processed a real assistant turn.
@@ -172,25 +173,34 @@ fi
 if [ -n "$safe_id" ]; then
   model_file="/tmp/${MODEL_STATE_PREFIX}-${safe_id}"
   if [ -f "$model_file" ]; then
-    cached_model=$(head -1 "$model_file")
-    cached_duration=$(tail -1 "$model_file")
-    # Reject non-numeric cached_duration (e.g. from a corrupted/truncated file)
-    cached_duration=$(printf '%s' "$cached_duration" | grep -E '^[0-9]+$' || echo 0)
-    cached_duration=${cached_duration:-0}
+    cached_model=$(sed -n '1p' "$model_file")
+    cached_ctx_size=$(sed -n '2p' "$model_file")
+    cached_duration=$(sed -n '3p' "$model_file")
+    # Migrate legacy 2-line cache: line 2 was duration_ms, line 3 missing
+    if [ -n "$cached_ctx_size" ] && [ -z "$cached_duration" ]; then
+      cached_duration="$cached_ctx_size"
+      cached_ctx_size=0
+    fi
+    # Reject non-numeric cached values (e.g. from a corrupted/truncated file)
+    case "$cached_ctx_size" in ""|*[!0-9]*) cached_ctx_size=0 ;; esac
+    case "$cached_duration" in ""|*[!0-9]*) cached_duration=0 ;; esac
     if [ "$duration_ms" -lt "$cached_duration" ] 2>/dev/null; then
       # duration_ms went backwards → session restarted; reset cache
-      [ "$model" != "unknown" ] && printf '%s\n%s\n' "$model" "$duration_ms" > "$model_file"
+      [ "$model" != "unknown" ] && printf '%s\n%s\n%s\n' "$model" "$ctx_size" "$duration_ms" > "$model_file"
     elif [ "$duration_ms" -gt "$cached_duration" ] 2>/dev/null && [ "$model" != "unknown" ]; then
       # New activity with a known model → update cache
-      printf '%s\n%s\n' "$model" "$duration_ms" > "$model_file"
+      printf '%s\n%s\n%s\n' "$model" "$ctx_size" "$duration_ms" > "$model_file"
     else
-      # No new activity, or model is unknown → keep cached model
-      [ -n "$cached_model" ] && model="$cached_model"
+      # No new activity, or model is unknown → keep cached model + context size
+      if [ -n "$cached_model" ]; then
+        model="$cached_model"
+        ctx_size="$cached_ctx_size"
+      fi
     fi
   elif [ "$model" != "unknown" ]; then
     # First invocation for this session → initialize cache
     # Skip initialization if model is unknown (jq failure) to avoid caching a bad value
-    printf '%s\n%s\n' "$model" "$duration_ms" > "$model_file"
+    printf '%s\n%s\n%s\n' "$model" "$ctx_size" "$duration_ms" > "$model_file"
   fi
 fi
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -41,7 +41,14 @@ make_json() {
   local rl_5h_reset="${10:-}"
   local rl_7d_pct="${11:-}"
   local rl_7d_reset="${12:-}"
+  local ctx_size="${13:-}"
   local base
+  local ctx_size_args=()
+  local ctx_size_filter="."
+  if [ -n "$ctx_size" ]; then
+    ctx_size_args=(--argjson ctxsz "$ctx_size")
+    ctx_size_filter=". | .context_window.context_window_size = \$ctxsz"
+  fi
   base=$(jq -n \
     --arg cwd "$cwd" \
     --arg sid "$session_id" \
@@ -51,6 +58,7 @@ make_json() {
     --argjson tin "$total_in" \
     --argjson tout "$total_out" \
     --argjson dur "$duration_ms" \
+    "${ctx_size_args[@]}" \
     '{
       cwd: $cwd,
       session_id: $sid,
@@ -58,7 +66,7 @@ make_json() {
       context_window: { used_percentage: $used, total_input_tokens: $tin, total_output_tokens: $tout },
       model: { display_name: $model },
       cost: { total_duration_ms: $dur }
-    }')
+    } | '"$ctx_size_filter")
   if [ -n "$rl_5h_pct" ] || [ -n "$rl_5h_reset" ] || [ -n "$rl_7d_pct" ] || [ -n "$rl_7d_reset" ]; then
     local rl_args=()
     local rl_filter="."

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -103,11 +103,15 @@ plain() {
 
 # Read model cache file for a session
 cached_model() {
-  head -1 "/tmp/claude-code-statusline-model-${1:-$TEST_SID}"
+  sed -n '1p' "/tmp/claude-code-statusline-model-${1:-$TEST_SID}"
+}
+
+cached_ctx_size() {
+  sed -n '2p' "/tmp/claude-code-statusline-model-${1:-$TEST_SID}"
 }
 
 cached_duration() {
-  tail -1 "/tmp/claude-code-statusline-model-${1:-$TEST_SID}"
+  sed -n '3p' "/tmp/claude-code-statusline-model-${1:-$TEST_SID}"
 }
 
 # Expire the first-usage display window for a session

--- a/test/model.bats
+++ b/test/model.bats
@@ -28,6 +28,26 @@ load 'helpers'
   [[ "$(plain)" == *"✦ Opus 4.6"* ]]
 }
 
+# ─── Context window size indicator ───
+
+@test "model: shows 1M suffix for 1M context" {
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" "" "" "" "" 1000000
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" == *"✦ Opus 4.6 1M"* ]]
+}
+
+@test "model: no 1M suffix for 200k context" {
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" "" "" "" "" 200000
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" != *"1M"* ]]
+}
+
+@test "model: no 1M suffix when context_window_size missing" {
+  run run_sl "Opus 4.6"
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" != *"1M"* ]]
+}
+
 @test "model: rejects garbled 'Op.6'" {
   run run_sl "Op.6"
   [ "$status" -eq 0 ]

--- a/test/model.bats
+++ b/test/model.bats
@@ -106,6 +106,15 @@ load 'helpers'
   [ "$(cached_model)" = "Opus 4.6" ]
 }
 
+@test "cache: ctx_size restored from cache alongside model" {
+  # Opus with 1M context cached
+  invoke "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" "" "" "" "" 1000000
+  # Same duration, different model+ctx_size from CC -- cache should win for both
+  run run_sl "Sonnet 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" "" "" "" "" 200000
+  [[ "$(plain)" == *"✦ Opus 4.6 1M"* ]]
+  [ "$(cached_ctx_size)" = "1000000" ]
+}
+
 @test "cache: updated when duration increases with known model" {
   invoke "Opus 4.6" 25 "$TEST_SID" 60000
   run run_sl "Sonnet 4.6" 25 "$TEST_SID" 120000
@@ -143,6 +152,25 @@ load 'helpers'
   invoke "Sonnet 4.6" 25 "${TEST_SID}-b" 60000
   [ "$(cached_model "${TEST_SID}-a")" = "Opus 4.6" ]
   [ "$(cached_model "${TEST_SID}-b")" = "Sonnet 4.6" ]
+}
+
+@test "cache: truncated 1-line cache file falls through gracefully" {
+  # Simulate a corrupted/truncated cache with only the model line
+  printf 'Opus 4.6\n' > "/tmp/claude-code-statusline-model-${TEST_SID}"
+  run run_sl "Sonnet 4.6" 25 "$TEST_SID" 60000
+  [ "$status" -eq 0 ]
+  # duration_ms (60000) > cached_duration (0, missing line), so cache is updated
+  [[ "$(plain)" == *"✦ Sonnet 4.6"* ]]
+  [ "$(cached_model)" = "Sonnet 4.6" ]
+}
+
+@test "cache: legacy 2-line cache migrates without flicker" {
+  # Simulate a pre-upgrade 2-line cache (model + duration, no ctx_size)
+  printf 'Opus 4.6\n60000\n' > "/tmp/claude-code-statusline-model-${TEST_SID}"
+  # Same duration -- "no new activity" path should restore cached model
+  run run_sl "Sonnet 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" "" "" "" "" 200000
+  [[ "$(plain)" == *"✦ Opus 4.6"* ]]
+  [ "$(cached_model)" = "Opus 4.6" ]
 }
 
 @test "cache: empty session_id bypasses caching" {


### PR DESCRIPTION
## Summary
- Extract `context_window.context_window_size` from the status line JSON input
- Display a dim "1M" suffix after the model name when running with 1M context, nothing for the default 200k

Closes #20

## Test plan
- [ ] `bats test/model.bats` -- new tests for 1M shown, 200k not shown, missing field not shown
- [ ] `bats test/` -- full suite passes with no regressions
- [ ] Pipe JSON with `"context_window_size": 1000000` into `statusline.sh` and confirm dim "1M" appears after model name
- [ ] Pipe JSON without `context_window_size` or with `200000` and confirm no "1M" suffix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the statusline JSON parsing and on-disk model cache format (with migration logic), which could affect status display across sessions if edge cases are missed.
> 
> **Overview**
> Adds support for reading `context_window.context_window_size` from the input JSON and displaying a dim `1M` suffix after the model name when the context window is ≥1,000,000.
> 
> Updates the per-session model cache from a 2-line to 3-line format to store `ctx_size` alongside `model`, including legacy-cache migration and corrupted/truncated-cache handling, and extends the Bats helpers/tests to cover the new indicator and cache behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88018b6abee4537701d0c7504ce55e590722d6e4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a context window size indicator that displays a "1M" marker in the status line for models with context windows of 1 million tokens or larger, shown immediately after the model label.

## Tests
* Added tests to validate the context window size indicator displays correctly based on model configuration thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->