### PR TITLE
Use 4-shade progress bar for finer granularity

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -82,6 +82,7 @@ eval "$(echo "$input" | jq -r '
   "transcript_path=\(.transcript_path // "" | @sh)",
   "used=\(.context_window.used_percentage // 0 | floor | @sh)",
   "model=\(.model.display_name // "unknown" | sub(" *\\(.*\\)"; "") | @sh)",
+  "ctx_size=\(.context_window.context_window_size // 0 | floor | @sh)",
   "total_in=\(.context_window.total_input_tokens // 0 | floor | @sh)",
   "total_out=\(.context_window.total_output_tokens // 0 | floor | @sh)",
   "duration_ms=\(.cost.total_duration_ms // 0 | floor | @sh)",
@@ -93,7 +94,7 @@ eval "$(echo "$input" | jq -r '
 
 # Defaults if jq fails or fields are missing
 cwd=${cwd:-}; session_id=${session_id:-}; transcript_path=${transcript_path:-}
-used=${used:-0}; model=${model:-unknown}
+used=${used:-0}; model=${model:-unknown}; ctx_size=${ctx_size:-0}
 total_in=${total_in:-0}; total_out=${total_out:-0}; duration_ms=${duration_ms:-0}
 rl_5h_pct=${rl_5h_pct:-}; rl_5h_reset=${rl_5h_reset:-}
 rl_7d_pct=${rl_7d_pct:-}; rl_7d_reset=${rl_7d_reset:-}
@@ -391,6 +392,9 @@ if [ -n "$branch" ]; then
   printf "%s" "$sep"
 fi
 printf "\033[38;5;252m✦ %s${reset}" "$model"
+if [ "$ctx_size" -ge 1000000 ] 2>/dev/null; then
+  printf " ${dim}1M${reset}"
+fi
 printf "${sep}${ctx_color}%s %s%%${reset}" "$bar" "$used"
 if [ "$tpm" -gt 0 ]; then
   if [ "$tpm" -ge 100000 ]; then

--- a/statusline.sh
+++ b/statusline.sh
@@ -401,7 +401,7 @@ if [ -n "$branch" ]; then
 fi
 printf "\033[38;5;252m✦ %s${reset}" "$model"
 if [ "$ctx_size" -ge 1000000 ] 2>/dev/null; then
-  printf " ${dim}1M${reset}"
+  printf " \033[38;5;252m1M${reset}"
 fi
 printf "${sep}${ctx_color}%s %s%%${reset}" "$bar" "$used"
 if [ "$tpm" -gt 0 ]; then

--- a/statusline.sh
+++ b/statusline.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Line 1: ⌥ branch  +N -N  ✦ model  ▓▓░░ N%  ϟ N tpm
+# Line 1: ⌥ branch  +N -N  ✦ model  ██▒░░ N%  ϟ N tpm
 # Line 2: 5h N% XhYm  7d N% XdYh   (shown when on pace / ≥75%)
 
 TPM_STATE_PREFIX="claude-code-statusline-tpm"
@@ -236,13 +236,21 @@ if [ -n "$safe_id" ]; then
   fi
 fi
 
-# 5-char progress bar (each bar = 20%)
-filled=$((used / 20))
-[ "$used" -ge 95 ] && filled=5
-[ "$filled" -gt 5 ] && filled=5
-case $filled in
-  0) bar="░░░░░" ;; 1) bar="▓░░░░" ;; 2) bar="▓▓░░░" ;; 3) bar="▓▓▓░░" ;; 4) bar="▓▓▓▓░" ;; 5) bar="▓▓▓▓▓" ;;
-esac
+# 5-char progress bar with 4 shades (░▒▓█), 20 visual steps
+bar=""
+for i in 0 1 2 3 4; do
+  slot_start=$((i * 20))
+  remainder=$((used - slot_start))
+  if [ "$remainder" -ge 20 ]; then
+    bar="${bar}█"
+  elif [ "$remainder" -ge 13 ]; then
+    bar="${bar}▓"
+  elif [ "$remainder" -ge 7 ]; then
+    bar="${bar}▒"
+  else
+    bar="${bar}░"
+  fi
+done
 
 # Context color gradient (no green/red to avoid clashing with diff stats)
 if [ "$used" -ge 75 ]; then

--- a/test/context.bats
+++ b/test/context.bats
@@ -4,44 +4,64 @@ load 'helpers'
 
 # ─── Context bar ───
 
-@test "bar: 0% shows empty" {
+@test "bar: 0% shows all empty" {
   run run_sl "Opus 4.6" 0
   [[ "$(plain)" == *"░░░░░ 0%"* ]]
 }
 
-@test "bar: 19% shows empty (below 20% threshold)" {
-  run run_sl "Opus 4.6" 19
-  [[ "$(plain)" == *"░░░░░ 19%"* ]]
+@test "bar: 6% stays empty (below +7 threshold)" {
+  run run_sl "Opus 4.6" 6
+  [[ "$(plain)" == *"░░░░░ 6%"* ]]
 }
 
-@test "bar: 20% shows one filled" {
+@test "bar: 7% shows light shade" {
+  run run_sl "Opus 4.6" 7
+  [[ "$(plain)" == *"▒░░░░ 7%"* ]]
+}
+
+@test "bar: 13% shows dark shade" {
+  run run_sl "Opus 4.6" 13
+  [[ "$(plain)" == *"▓░░░░ 13%"* ]]
+}
+
+@test "bar: 20% shows one full block" {
   run run_sl "Opus 4.6" 20
-  [[ "$(plain)" == *"▓░░░░ 20%"* ]]
+  [[ "$(plain)" == *"█░░░░ 20%"* ]]
 }
 
-@test "bar: 40% shows two filled" {
+@test "bar: 40% shows two full blocks" {
   run run_sl "Opus 4.6" 40
-  [[ "$(plain)" == *"▓▓░░░ 40%"* ]]
+  [[ "$(plain)" == *"██░░░ 40%"* ]]
 }
 
-@test "bar: 60% shows three filled" {
+@test "bar: 47% shows two full + light shade" {
+  run run_sl "Opus 4.6" 47
+  [[ "$(plain)" == *"██▒░░ 47%"* ]]
+}
+
+@test "bar: 57% shows two full + dark shade" {
+  run run_sl "Opus 4.6" 57
+  [[ "$(plain)" == *"██▓░░ 57%"* ]]
+}
+
+@test "bar: 60% shows three full blocks" {
   run run_sl "Opus 4.6" 60
-  [[ "$(plain)" == *"▓▓▓░░ 60%"* ]]
+  [[ "$(plain)" == *"███░░ 60%"* ]]
 }
 
-@test "bar: 80% shows four filled" {
+@test "bar: 80% shows four full blocks" {
   run run_sl "Opus 4.6" 80
-  [[ "$(plain)" == *"▓▓▓▓░ 80%"* ]]
+  [[ "$(plain)" == *"████░ 80%"* ]]
 }
 
-@test "bar: 95% shows full (special case)" {
-  run run_sl "Opus 4.6" 95
-  [[ "$(plain)" == *"▓▓▓▓▓ 95%"* ]]
+@test "bar: 93% shows four full + dark shade" {
+  run run_sl "Opus 4.6" 93
+  [[ "$(plain)" == *"████▓ 93%"* ]]
 }
 
-@test "bar: 100% shows full" {
+@test "bar: 100% shows all full" {
   run run_sl "Opus 4.6" 100
-  [[ "$(plain)" == *"▓▓▓▓▓ 100%"* ]]
+  [[ "$(plain)" == *"█████ 100%"* ]]
 }
 
 # ─── Context color tiers ───
@@ -49,23 +69,23 @@ load 'helpers'
 @test "color: dim below 35%" {
   run run_sl "Opus 4.6" 34
   # \033[38;5;247m = dim gray
-  [[ "$output" == *$'\033[38;5;247m'"▓"* ]]
+  [[ "$output" == *$'\033[38;5;247m'"█"* ]]
 }
 
 @test "color: yellow-green at 35%" {
   run run_sl "Opus 4.6" 35
   # \033[38;5;148m = yellow-green
-  [[ "$output" == *$'\033[38;5;148m'"▓"* ]]
+  [[ "$output" == *$'\033[38;5;148m'"█"* ]]
 }
 
 @test "color: yellow at 50%" {
   run run_sl "Opus 4.6" 50
   # \033[93m = yellow
-  [[ "$output" == *$'\033[93m'"▓"* ]]
+  [[ "$output" == *$'\033[93m'"██"* ]]
 }
 
 @test "color: orange at 75%" {
   run run_sl "Opus 4.6" 75
   # \033[38;5;208m = orange
-  [[ "$output" == *$'\033[38;5;208m'"▓"* ]]
+  [[ "$output" == *$'\033[38;5;208m'"███"* ]]
 }

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -41,7 +41,14 @@ make_json() {
   local rl_5h_reset="${10:-}"
   local rl_7d_pct="${11:-}"
   local rl_7d_reset="${12:-}"
+  local ctx_size="${13:-}"
   local base
+  local ctx_size_args=()
+  local ctx_size_filter="."
+  if [ -n "$ctx_size" ]; then
+    ctx_size_args=(--argjson ctxsz "$ctx_size")
+    ctx_size_filter=". | .context_window.context_window_size = \$ctxsz"
+  fi
   base=$(jq -n \
     --arg cwd "$cwd" \
     --arg sid "$session_id" \
@@ -51,6 +58,7 @@ make_json() {
     --argjson tin "$total_in" \
     --argjson tout "$total_out" \
     --argjson dur "$duration_ms" \
+    "${ctx_size_args[@]}" \
     '{
       cwd: $cwd,
       session_id: $sid,
@@ -58,7 +66,7 @@ make_json() {
       context_window: { used_percentage: $used, total_input_tokens: $tin, total_output_tokens: $tout },
       model: { display_name: $model },
       cost: { total_duration_ms: $dur }
-    }')
+    } | '"$ctx_size_filter")
   if [ -n "$rl_5h_pct" ] || [ -n "$rl_5h_reset" ] || [ -n "$rl_7d_pct" ] || [ -n "$rl_7d_reset" ]; then
     local rl_args=()
     local rl_filter="."

--- a/test/model.bats
+++ b/test/model.bats
@@ -28,6 +28,26 @@ load 'helpers'
   [[ "$(plain)" == *"✦ Opus 4.6"* ]]
 }
 
+# ─── Context window size indicator ───
+
+@test "model: shows 1M suffix for 1M context" {
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" "" "" "" "" 1000000
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" == *"✦ Opus 4.6 1M"* ]]
+}
+
+@test "model: no 1M suffix for 200k context" {
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "" "" "" "" "" "" 200000
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" != *"1M"* ]]
+}
+
+@test "model: no 1M suffix when context_window_size missing" {
+  run run_sl "Opus 4.6"
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" != *"1M"* ]]
+}
+
 @test "model: rejects garbled 'Op.6'" {
   run run_sl "Op.6"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary
- Replace 2-state (`▓░`) bar with 4-shade (`░▒▓█`) bar, increasing from 5 to 20 visual steps
- Each 20% slot uses thresholds at +7% and +13% to select intermediate shades
- 57% now renders as `██▓░░` instead of `▓▓░░░`

## Test plan
- [ ] `bats test/` passes all 94 tests
- [ ] Visually verify bar renders correctly at key thresholds (0%, 7%, 13%, 20%, 47%, 57%, 93%, 100%)

Closes #22

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to statusline rendering logic and test updates, with no security-sensitive or persistent data handling.
> 
> **Overview**
> Updates `statusline.sh` to render context usage as a 5-character **4-shade** bar (`░▒▓█`) for finer granularity (20 visual steps) instead of the previous binary fill.
> 
> Also extracts `context_window.context_window_size` from input JSON and appends a `1M` suffix next to the model when the context window is at least 1,000,000 tokens. Tests are updated/expanded to cover the new bar thresholds and the new `1M` indicator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9c1ee8288c2cab699cee16448aea39d90aa8a03. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->