### PR TITLE
Rescale context percentage to autocompact point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Context percentage rescaled so 100% matches the actual autocompact point instead of the raw window size. Displayed values will appear higher than before (e.g. 70% raw → 83% displayed on a 200k window) because Claude Code reserves ~33k tokens as an autocompact buffer. This is deliberate — the old display suggested headroom that didn't exist
+- Added red color tier at 90%+ for a visible compaction-imminent signal (previous top tier was orange at 75%+)
+- Respect `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` when computing the effective capacity
+
 ## 1.4.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,12 +18,14 @@ A minimal Claude Code statusline showing branch, diff, model, context, throughpu
 
 ## What it shows
 
-- **Branch** – current git branch
-- **Diff** – uncommitted additions and deletions
-- **Model** – active Claude model
-- **Context** – usage bar and percentage. Grey under 35%, yellow-green under 50%, yellow under 75%, orange above. Start a new conversation before 50% for best results.
-- **Throughput** – tokens per minute. Grey under 1k, yellow at 1k, orange at 5k, red at 10k, violet at 20k.
-- **Rate limits** – 5-hour and weekly usage with countdown. Grey under 50%, yellow at 50%, orange at 75%, red at 90%. Shown on first use of each session, when on pace to hit the limit, and at 75%. If hidden, you're within a comfortable pace.
+|   |   |   |
+|---|---|---|
+| **Branch** | Current git branch |  |
+| **Diff** | Uncommitted additions and deletions |  |
+| **Model** | Active Claude model |  |
+| **Context** | Usage bar and percentage, scaled so 100% matches the actual autocompact point | Grey <35%, yellow-green 35%, yellow 50%, orange 75%, red 90% |
+| **Throughput** | Tokens per minute | Grey <1k, yellow 1k, orange 5k, red 10k, violet 20k |
+| **Rate limits** | 5-hour and 7-day usage with countdown. Shown on first use, when on pace to hit the limit, and at or above 75%. Hidden means comfortable pace | Grey <50%, yellow 50%, orange 75%, red 90% |
 
 Indicators without data are hidden rather than shown empty.
 

--- a/statusline.sh
+++ b/statusline.sh
@@ -204,6 +204,32 @@ if [ -n "$safe_id" ]; then
   fi
 fi
 
+# Rescale context percentage so 100% displayed matches the actual autocompact
+# point. Claude Code reserves ~33k tokens as an autocompact buffer, so without
+# rescaling, users see "70% used" and get surprised by compaction at what looks
+# like 83%. Runs after the cache block because cached ctx_size may replace the
+# live value.
+effective_ctx_size=$ctx_size
+[ "$effective_ctx_size" -le 0 ] 2>/dev/null && effective_ctx_size=200000
+effective_size=$((effective_ctx_size - 33000))
+case "${CLAUDE_AUTOCOMPACT_PCT_OVERRIDE:-}" in
+  ""|*[!0-9]*) ;;
+  *)
+    if [ "$CLAUDE_AUTOCOMPACT_PCT_OVERRIDE" -ge 1 ] 2>/dev/null \
+      && [ "$CLAUDE_AUTOCOMPACT_PCT_OVERRIDE" -le 100 ] 2>/dev/null; then
+      effective_size=$((effective_ctx_size * CLAUDE_AUTOCOMPACT_PCT_OVERRIDE / 100))
+    fi
+    ;;
+esac
+if [ "$effective_size" -gt 0 ] 2>/dev/null; then
+  rescaled=$((used * effective_ctx_size / effective_size))
+  if [ "$rescaled" -gt 100 ]; then
+    used=100
+  else
+    used=$rescaled
+  fi
+fi
+
 # Sliding window TPM (overrides full-session average when enough data)
 if [ -n "$safe_id" ]; then
   state_file="/tmp/${TPM_STATE_PREFIX}-${safe_id}"
@@ -262,8 +288,10 @@ for i in 0 1 2 3 4; do
   fi
 done
 
-# Context color gradient (no green/red to avoid clashing with diff stats)
-if [ "$used" -ge 75 ]; then
+# Context color gradient, relative to the rescaled `used` value (100% = autocompact point).
+if [ "$used" -ge 90 ]; then
+  ctx_color="\033[91m"          # red: compaction imminent or past
+elif [ "$used" -ge 75 ]; then
   ctx_color="\033[38;5;208m"    # orange
 elif [ "$used" -ge 50 ]; then
   ctx_color="\033[93m"          # yellow

--- a/test/context.bats
+++ b/test/context.bats
@@ -89,3 +89,9 @@ load 'helpers'
   # \033[38;5;208m = orange
   [[ "$output" == *$'\033[38;5;208m'"███"* ]]
 }
+
+@test "color: red at 90%" {
+  run run_sl "Opus 4.6" 90
+  # \033[91m = red
+  [[ "$output" == *$'\033[91m'"████"* ]]
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -87,16 +87,16 @@ make_json() {
 }
 
 # Run the script, capturing output for assertions via `run`.
-# Sets CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=100 so rescaling is an identity — tests
+# Forces CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=100 so rescaling is an identity — tests
 # that pass a raw `used_percentage` see it displayed unchanged. Tests that need
-# real rescale behavior should export the env var themselves before calling.
+# real rescale behavior should use run_sl_rescaled instead.
 run_sl() {
-  make_json "$@" | env CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="${CLAUDE_AUTOCOMPACT_PCT_OVERRIDE:-100}" sh "$SCRIPT"
+  make_json "$@" | env CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=100 sh "$SCRIPT"
 }
 
 # Set up cache state without capturing output
 invoke() {
-  make_json "$@" | env CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="${CLAUDE_AUTOCOMPACT_PCT_OVERRIDE:-100}" sh "$SCRIPT" > /dev/null
+  make_json "$@" | env CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=100 sh "$SCRIPT" > /dev/null
 }
 
 # Run the script without the identity-override, for tests that exercise the

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -86,14 +86,24 @@ make_json() {
   fi
 }
 
-# Run the script, capturing output for assertions via `run`
+# Run the script, capturing output for assertions via `run`.
+# Sets CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=100 so rescaling is an identity — tests
+# that pass a raw `used_percentage` see it displayed unchanged. Tests that need
+# real rescale behavior should export the env var themselves before calling.
 run_sl() {
-  make_json "$@" | sh "$SCRIPT"
+  make_json "$@" | env CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="${CLAUDE_AUTOCOMPACT_PCT_OVERRIDE:-100}" sh "$SCRIPT"
 }
 
 # Set up cache state without capturing output
 invoke() {
-  make_json "$@" | sh "$SCRIPT" > /dev/null
+  make_json "$@" | env CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="${CLAUDE_AUTOCOMPACT_PCT_OVERRIDE:-100}" sh "$SCRIPT" > /dev/null
+}
+
+# Run the script without the identity-override, for tests that exercise the
+# real rescale math. Inherits CLAUDE_AUTOCOMPACT_PCT_OVERRIDE from the caller
+# when set (so individual tests can inject their own override value).
+run_sl_rescaled() {
+  make_json "$@" | sh "$SCRIPT"
 }
 
 # Strip ANSI escape codes from $output

--- a/test/rescale.bats
+++ b/test/rescale.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+
+load 'helpers'
+
+# These tests exercise the real rescale math (no CLAUDE_AUTOCOMPACT_PCT_OVERRIDE
+# identity shim). The rescale formula:
+#   effective_size = ctx_size - 33000  (or ctx_size * override/100 when override set)
+#   displayed      = used_percentage * ctx_size / effective_size
+# Capped at 100%, with a red color tier past the autocompact threshold.
+
+# ─── 200k window (default) ───
+
+@test "rescale 200k: 0% raw stays 0%" {
+  run run_sl_rescaled "Opus 4.6" 0 "" "" "" "" "" "" "" "" "" "" 200000
+  [[ "$(plain)" == *" 0%"* ]]
+}
+
+@test "rescale 200k: 50% raw shows ~59%" {
+  # 50 * 200000 / 167000 = 59.88 → 59
+  run run_sl_rescaled "Opus 4.6" 50 "" "" "" "" "" "" "" "" "" "" 200000
+  [[ "$(plain)" == *" 59%"* ]]
+}
+
+@test "rescale 200k: 70% raw shows ~83%" {
+  # 70 * 200000 / 167000 = 83.83 → 83
+  run run_sl_rescaled "Opus 4.6" 70 "" "" "" "" "" "" "" "" "" "" 200000
+  [[ "$(plain)" == *" 83%"* ]]
+}
+
+@test "rescale 200k: 84% raw caps at 100%" {
+  # 84 * 200000 / 167000 = 100.59 → 100 (over threshold)
+  run run_sl_rescaled "Opus 4.6" 84 "" "" "" "" "" "" "" "" "" "" 200000
+  [[ "$(plain)" == *" 100%"* ]]
+}
+
+@test "rescale 200k: 95% raw displays 100%" {
+  run run_sl_rescaled "Opus 4.6" 95 "" "" "" "" "" "" "" "" "" "" 200000
+  [[ "$(plain)" == *" 100%"* ]]
+}
+
+# ─── 1M window ───
+
+@test "rescale 1M: 50% raw shows ~51%" {
+  # 50 * 1000000 / 967000 = 51.7 → 51
+  run run_sl_rescaled "Opus 4.6" 50 "" "" "" "" "" "" "" "" "" "" 1000000
+  [[ "$(plain)" == *" 51%"* ]]
+}
+
+@test "rescale 1M: 96% raw shows 99%" {
+  # 96 * 1000000 / 967000 = 99.27 → 99
+  run run_sl_rescaled "Opus 4.6" 96 "" "" "" "" "" "" "" "" "" "" 1000000
+  [[ "$(plain)" == *" 99%"* ]]
+}
+
+@test "rescale 1M: 97% raw caps at 100%" {
+  # 97 * 1000000 / 967000 = 100.31 → 100 (over threshold)
+  run run_sl_rescaled "Opus 4.6" 97 "" "" "" "" "" "" "" "" "" "" 1000000
+  [[ "$(plain)" == *" 100%"* ]]
+}
+
+# ─── Missing ctx_size falls back to 200k ───
+
+@test "rescale: missing ctx_size treated as 200k" {
+  # No ctx_size passed → JSON omits it → script defaults 0 → treated as 200000
+  # 50 raw should render as 59
+  run run_sl_rescaled "Opus 4.6" 50
+  [[ "$(plain)" == *" 59%"* ]]
+}
+
+# ─── CLAUDE_AUTOCOMPACT_PCT_OVERRIDE ───
+
+@test "rescale override: 90 with 200k, 45 raw shows 50%" {
+  # effective = 200000 * 90/100 = 180000
+  # displayed = 45 * 200000 / 180000 = 50
+  CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=90 run run_sl_rescaled "Opus 4.6" 45 "" "" "" "" "" "" "" "" "" "" 200000
+  [[ "$(plain)" == *" 50%"* ]]
+}
+
+@test "rescale override: 100 with 200k is identity" {
+  # effective = ctx_size, displayed = raw
+  CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=100 run run_sl_rescaled "Opus 4.6" 70 "" "" "" "" "" "" "" "" "" "" 200000
+  [[ "$(plain)" == *" 70%"* ]]
+}
+
+@test "rescale override: garbage value ignored, falls back to 33k buffer" {
+  # Invalid override → default 33k buffer path
+  # 50 * 200000 / 167000 = 59
+  CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=garbage run run_sl_rescaled "Opus 4.6" 50 "" "" "" "" "" "" "" "" "" "" 200000
+  [[ "$(plain)" == *" 59%"* ]]
+}
+
+@test "rescale override: out of range value ignored" {
+  # 0 and 101 should be rejected
+  CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=101 run run_sl_rescaled "Opus 4.6" 50 "" "" "" "" "" "" "" "" "" "" 200000
+  [[ "$(plain)" == *" 59%"* ]]
+}
+
+# ─── Red color kicks in near compaction ───
+
+@test "rescale color: 90%+ displayed uses red" {
+  # 76 raw on 200k → rescaled 91 → red tier (≥90)
+  run run_sl_rescaled "Opus 4.6" 76 "" "" "" "" "" "" "" "" "" "" 200000
+  [[ "$output" == *$'\033[91m'* ]]
+}
+
+@test "rescale color: at threshold (capped 100%) uses red" {
+  # 90 raw on 200k → rescaled 107 → capped 100 → red (≥90)
+  run run_sl_rescaled "Opus 4.6" 90 "" "" "" "" "" "" "" "" "" "" 200000
+  [[ "$output" == *$'\033[91m'"█████"* ]]
+}
+
+@test "rescale color: 75-89% displayed uses orange" {
+  # 70 raw on 200k → rescaled 83 → orange tier (75-89)
+  run run_sl_rescaled "Opus 4.6" 70 "" "" "" "" "" "" "" "" "" "" 200000
+  [[ "$output" == *$'\033[38;5;208m'* ]]
+  [[ "$output" != *$'\033[91m'"█"* ]]
+}


### PR DESCRIPTION
## Summary

On a 200k window, autocompact kicked in around 83% — well before the statusline showed 100%, which felt like the session was getting cut off unexpectedly. This rescales the display so 100% lines up with the actual compaction point, giving accurate headroom at a glance.

- Subtract the ~33k autocompact buffer from effective capacity so 100% displayed = compaction imminent
- Add red 90%+ color tier as a final warning before compaction
- Respect `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` (1-100) to tune the effective-capacity ratio if the buffer changes

## Test plan

- [x] `bats test/` passes (114 tests, including new `test/rescale.bats`)
- [x] 50% raw on 200k window displays as 59%
- [x] 70% raw on 200k window displays as 83% in orange
- [x] 90% raw on 200k window caps at 100% in red
- [x] 50% raw on 1M window displays as 51%
- [x] `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=100` is identity (rescaling disabled)
- [x] Invalid override values fall back to the default 33k buffer

Closes #24

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core context-percentage calculation and its color thresholds, which can affect user behavior and perceived headroom. Logic is arithmetic-heavy but is covered by new targeted tests and retains safe fallbacks for missing/invalid inputs.
> 
> **Overview**
> Context usage display is **rescaled so `100%` aligns with the autocompact point** (accounting for the ~33k token buffer), and the computed percentage is now capped at `100%`.
> 
> Adds a **new red warning tier at `>=90%`** for context usage, and honors `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` (1–100) when computing effective capacity.
> 
> Updates docs (`README.md`, `CHANGELOG.md`) and test harnesses: existing context tests run with an identity override, and a new `test/rescale.bats` suite validates rescaling across 200k/1M windows, missing `ctx_size` fallback, override handling, and color tier transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a045b7a8c17fddfdeb9103477f8789c7f958441f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Context percentage now rescales so 100% aligns with the actual autocompact point, increasing displayed percentages.
  * New red warning tier at 90%+ (previously top tier was orange at 75%+).
  * Capacity computation now respects a configurable autocompact override when present.
* **Documentation**
  * README and changelog updated: clearer table layout, reworded Context and Rate indicators (Rate now shows "5‑hour and 7‑day usage" and displays at 75%+).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->