### PR TITLE
Display million-tier TPM and guard against resume spikes

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -207,12 +207,33 @@ fi
 # Sliding window TPM (overrides full-session average when enough data)
 if [ -n "$safe_id" ]; then
   state_file="/tmp/${TPM_STATE_PREFIX}-${safe_id}"
-  [ -f "$state_file" ] || : > "$state_file"
+  restart_sentinel="${state_file}.restart"
+  # If the state file is missing (eviction or first run), clear any orphaned
+  # sentinel so we don't hide TPM forever when the two files get out of sync.
+  if [ ! -f "$state_file" ]; then
+    : > "$state_file"
+    rm -f "$restart_sentinel"
+  fi
 
-  # Detect session restart (duration_ms went backwards)
+  # Detect session restart (duration_ms went backwards). When we can prove the
+  # resumed session has at least as many tokens as before, seed the state file
+  # with a synthetic baseline at ms=0 so the first post-restart sample produces
+  # a real window_tpm (delta = post-restart tokens / post-restart duration).
+  # When prev_tok > total_tokens (context trim, etc.) the baseline would yield
+  # a negative delta and keep the sentinel set for up to TPM_WINDOW_MS, so we
+  # truncate instead and let the natural sliding window recover after two real
+  # samples. The sentinel forces tpm=0 until window_tpm is non-empty/positive.
   last_ms=$(tail -n 1 "$state_file" 2>/dev/null | awk '$1 ~ /^[0-9]+$/ { print $1 }')
   if [ -n "$last_ms" ] && [ "$duration_ms" -lt "$last_ms" ] 2>/dev/null; then
-    : > "$state_file"
+    prev_tok=$(tail -n 1 "$state_file" 2>/dev/null \
+               | awk '$1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ { print $2 }')
+    if [ -n "$prev_tok" ] && [ "$prev_tok" -gt 0 ] 2>/dev/null \
+       && [ "$total_tokens" -gt "$prev_tok" ] 2>/dev/null; then
+      printf '0 %s\n' "$prev_tok" > "$state_file"
+    else
+      : > "$state_file"
+    fi
+    : > "$restart_sentinel"
   fi
 
   cutoff=$((duration_ms - TPM_WINDOW_MS))
@@ -240,9 +261,14 @@ if [ -n "$safe_id" ]; then
 
   [ -f "$tmpfile" ] && mv "$tmpfile" "$state_file"
 
-  # Negative deltas (e.g. context window reset) produce negative TPM — intentionally ignored
+  # When the awk produced a usable rate, take it and clear any restart sentinel.
+  # Otherwise (empty / negative window_tpm), the sentinel keeps the segment
+  # hidden until a real post-restart sample pair produces a positive rate.
   if [ -n "$window_tpm" ] && [ "$window_tpm" -gt 0 ] 2>/dev/null; then
     tpm=$window_tpm
+    rm -f "$restart_sentinel"
+  elif [ -f "$restart_sentinel" ]; then
+    tpm=0
   fi
 fi
 
@@ -415,14 +441,20 @@ if [ "$ctx_size" -ge 1000000 ] 2>/dev/null; then
 fi
 printf "${sep}${ctx_color}%s %s%%${reset}" "$bar" "$used"
 if [ "$tpm" -gt 0 ]; then
-  if [ "$tpm" -ge 100000 ]; then
+  if [ "$tpm" -ge 100000000 ]; then
+    tpm_display="$((tpm / 1000000))M"
+  elif [ "$tpm" -ge 1000000 ]; then
+    tpm_display="$((tpm / 1000000)).$((tpm % 1000000 / 100000))M"
+  elif [ "$tpm" -ge 100000 ]; then
     tpm_display="$((tpm / 1000))k"
   elif [ "$tpm" -ge 1000 ]; then
     tpm_display="$((tpm / 1000)).$((tpm % 1000 / 100))k"
   else
     tpm_display="$tpm"
   fi
-  if [ "$tpm" -ge 20000 ]; then
+  if [ "$tpm" -ge 1000000 ]; then
+    bolt="\033[38;5;198mϟ${dim}"  # hot pink — ludicrous tier, likely a measurement glitch
+  elif [ "$tpm" -ge 20000 ]; then
     bolt="\033[38;5;57mϟ${dim}"   # deep violet
   elif [ "$tpm" -ge 10000 ]; then
     bolt="\033[91mϟ${dim}"        # red

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -21,6 +21,7 @@ cleanup_state() {
   sid=$(printf '%s' "$1" | tr -dc 'a-zA-Z0-9_-')
   rm -f "/tmp/claude-code-statusline-model-${sid}"
   rm -f "/tmp/claude-code-statusline-tpm-${sid}"
+  rm -f "/tmp/claude-code-statusline-tpm-${sid}.restart"
   rm -f "/tmp/claude-code-statusline-subagent-${sid}"
   rm -f "/tmp/claude-code-statusline-usage-${sid}"
 }

--- a/test/tpm.bats
+++ b/test/tpm.bats
@@ -35,6 +35,18 @@ load 'helpers'
   [[ "$(plain)" == *"100k tpm"* ]]
 }
 
+@test "tpm: shows N.NM for 1M-99.9M" {
+  # 1500000 tokens in 60s = 1500000 tpm
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 1000000 500000
+  [[ "$(plain)" == *"1.5M tpm"* ]]
+}
+
+@test "tpm: shows integer M for 100M+" {
+  # 100000000 tokens in 60s = 100000000 tpm
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 60000000 40000000
+  [[ "$(plain)" == *"100M tpm"* ]]
+}
+
 # ─── TPM bolt colors ───
 
 @test "bolt: no color below 1000 tpm" {
@@ -71,6 +83,12 @@ load 'helpers'
   [[ "$output" == *$'\033[38;5;57m'"ϟ"* ]]
 }
 
+@test "bolt: hot pink at 1M tpm" {
+  # 1500000 tokens in 60s = 1500000 tpm
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 1000000 500000
+  [[ "$output" == *$'\033[38;5;198m'"ϟ"* ]]
+}
+
 # ─── TPM sliding window ───
 
 @test "tpm: first invocation uses full-session average" {
@@ -87,10 +105,47 @@ load 'helpers'
   [[ "$(plain)" == *"1.0k tpm"* ]]
 }
 
-@test "tpm: session restart clears window" {
+@test "tpm: session restart hides segment when token delta is negative" {
+  # Prior session ended with 80000 tokens at t=120s
   invoke "Opus 4.6" 25 "$TEST_SID" 120000 50000 30000
-  # Duration goes backward -> restart -> window resets
-  # 1000 tokens in 5s = 12000 tpm
+  # Resumed session reports fewer total tokens (e.g. context trim).
+  # Without the mitigation this would display the spurious full-session
+  # average (1000 tok / 5s = 12000 tpm). Sentinel keeps the segment hidden.
   run run_sl "Opus 4.6" 25 "$TEST_SID" 5000 600 400
-  [[ "$(plain)" == *"12.0k tpm"* ]]
+  [[ "$(plain)" != *"tpm"* ]]
+}
+
+@test "tpm: session restart recovers post-resume rate via synthetic baseline" {
+  # Prior session ended with 50000 tokens at t=600s
+  invoke "Opus 4.6" 25 "$TEST_SID" 600000 30000 20000
+  # Resumed session: 5000 new tokens in 10s of post-resume time.
+  # Baseline (0, 50000) + current (10000, 55000) -> window_tpm = 5000*60/10 = 30000
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 10000 35000 20000
+  [[ "$(plain)" == *"30.0k tpm"* ]]
+}
+
+@test "tpm: sentinel clears once a positive window_tpm is produced" {
+  # Pre-resume: 80000 tokens. Resume with 1000 tokens (trim case) -> truncate, sentinel set.
+  invoke "Opus 4.6" 25 "$TEST_SID" 120000 50000 30000
+  invoke "Opus 4.6" 25 "$TEST_SID" 5000 600 400          # state: 5000 1000, sentinel set
+  # Continued post-resume activity produces a positive delta -> sentinel clears.
+  # delta = 2000-1000 = 1000 tokens over 60000ms = 1000 tpm
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 65000 1200 800
+  [[ "$(plain)" == *"1.0k tpm"* ]]
+}
+
+@test "tpm: session restart with zero prior tokens hides segment" {
+  # Prior session recorded a zero-token sample. prev_tok=0 -> truncate path, sentinel set.
+  invoke "Opus 4.6" 25 "$TEST_SID" 60000 0 0
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 5000 600 400
+  [[ "$(plain)" != *"tpm"* ]]
+}
+
+@test "tpm: orphaned sentinel is cleared when state file is missing" {
+  # Simulate /tmp eviction: sentinel exists but state file does not.
+  : > "/tmp/claude-code-statusline-tpm-${TEST_SID}.restart"
+  rm -f "/tmp/claude-code-statusline-tpm-${TEST_SID}"
+  # First invocation should clear the orphaned sentinel and display normally.
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000
+  [[ "$(plain)" == *"8.0k tpm"* ]]
 }


### PR DESCRIPTION
## Summary
- Add `M` (million) display unit to the TPM formatter and a hot-pink bolt color (256-color 198) for the `>= 1M` tier
- Hide the spurious multi-million TPM that surfaces immediately after a session resume by seeding the sliding-window state file with a synthetic baseline `(0, prev_tok)` and guarding with a `.restart` sentinel that forces `tpm=0` until a positive `window_tpm` is produced
- Truncate (no baseline) when `total_tokens <= prev_tok` so context-trim cases recover after two real post-resume samples instead of staying hidden for up to 5 minutes
- Clear orphaned sentinels when the state file is missing (handles `/tmp` eviction races)

## Test plan
- [x] `bats test/tpm.bats` — 20/20 passing, including new tests for M unit, hot-pink color, baseline recovery, sentinel suppression on negative delta, sentinel clearing once a positive window_tpm appears, zero-prior-tokens path, and orphaned-sentinel cleanup
- [x] `bats test/` — full suite 104/104 passing
- [x] Manual smoke test: piped synthetic JSON for 600 / 1.5M / 100M tpm — formatter and color tiers render correctly
- [x] Manual resume-scenario smoke test: pre-resume reading shows normally, post-resume invocation hides the would-be spike, follow-up invocation displays the recovered post-resume rate

Closes #26

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stateful TPM computation and restart detection logic in `statusline.sh`, which could hide or misreport TPM if edge cases aren’t covered. Scope is limited to local display/state files with expanded bats coverage.
> 
> **Overview**
> Improves the statusline TPM segment by adding `M`-unit formatting (including a new hot-pink bolt tier for `>= 1M`) so very large rates render compactly.
> 
> Hardens sliding-window TPM across session resumes by introducing a `.restart` sentinel and optional synthetic baseline seeding to prevent spurious post-resume spikes/negative deltas; also clears orphaned sentinels when the `/tmp` state file is missing. Tests are extended to cover the new formatting tiers and the restart/sentinel behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 285ef97611d882ef6d265416ed8336915295e426. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added megatoken formatting and coloring for token rates ≥1,000,000 tpm.
  * Enhanced session-restart detection with improved recovery behavior.

* **Bug Fixes**
  * Fixed potential indefinite TPM suppression after restart by clearing orphaned sentinel files.
  * Improved session-restart handling to preserve token state when appropriate.

* **Tests**
  * Added comprehensive test coverage for high token-rate display formatting and restart scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->