### PR TITLE
#28: Accept model names with a bare major version

### DIFF
--- a/statusline.sh
+++ b/statusline.sh
@@ -105,11 +105,11 @@ case "$rl_7d_reset" in ""|*[!0-9]*) rl_7d_reset="" ;; esac
 case "$rl_5h_pct" in ""|*[!0-9.]*|*.*.*) rl_5h_pct="" ;; esac
 case "$rl_7d_pct" in ""|*[!0-9.]*|*.*.*) rl_7d_pct="" ;; esac
 
-# Validate model name: must match "Name N.N" pattern (e.g. "Opus 4.6", "Sonnet 4.6", "Haiku 4.5")
+# Validate model name: must match "Name N" or "Name N.N" (e.g. "Fable 5", "Opus 4.6", "Haiku 4.5")
 # Garbled names from Claude Code (e.g. "Op.6") are treated as unknown so they don't pollute the cache
 case "$model" in
   unknown) ;;
-  *) echo "$model" | grep -qE '^[A-Z][a-z]+ [0-9]+\.[0-9]+$' || model="unknown" ;;
+  *) echo "$model" | grep -qE '^[A-Z][a-z]+ [0-9]+(\.[0-9]+)?$' || model="unknown" ;;
 esac
 
 # Session-scoped state key (used by model cache and sliding window TPM)

--- a/test/model.bats
+++ b/test/model.bats
@@ -22,6 +22,12 @@ load 'helpers'
   [[ "$(plain)" == *"✦ Haiku 4.5"* ]]
 }
 
+@test "model: accepts bare major version 'Fable 5'" {
+  run run_sl "Fable 5"
+  [ "$status" -eq 0 ]
+  [[ "$(plain)" == *"✦ Fable 5"* ]]
+}
+
 @test "model: strips parenthetical suffix 'Opus 4.6 (1M context)'" {
   run run_sl "Opus 4.6 (1M context)"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary
- Make the minor version optional in the model validation regex so names like "Fable 5" pass instead of displaying as `✦ unknown`
- Garbled names (`Op.6`, `Son`, lowercase, trailing text, multi-word) are still rejected
- Add a test for the bare-major-version case

Closes #28

## Test plan
- [x] `bats test/` — all 122 tests pass, including the new `model: accepts bare major version 'Fable 5'` test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small display-validation tweak in the statusline script with no auth, data, or API impact.
> 
> **Overview**
> The statusline **model name validator** now accepts a bare major version (e.g. `Fable 5`) in addition to `Name N.N` (e.g. `Opus 4.6`), so those names show on the status line instead of `✦ unknown`.
> 
> The regex in `statusline.sh` changes from requiring a minor version to making `(\.[0-9]+)?` optional. Invalid or garbled names are still rejected via the same pattern and existing tests.
> 
> A **bats** case asserts that `Fable 5` renders as `✦ Fable 5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4b18189dbaea79010fca0714598e8f9945c6931. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model name format validation now accepts both single-digit versions (e.g., "Fable 5") and dotted versions (e.g., "Fable 5.0"), providing greater flexibility in model naming.

* **Tests**
  * Added test coverage to ensure bare major-version model names are correctly parsed and displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->