### PR TITLE
#30: Distinguish git worktrees from the main checkout in the branch indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Or clone and symlink: `git clone https://github.com/levibe/claude-code-statuslin
 - Caps line counting at 10k to avoid slowdowns on large diffs
 - TPM uses a 5-minute sliding window and includes subagent token usage
 - Shows short SHA on detached HEAD; falls back to symbolic ref in empty repos
+- Marks a linked git worktree with a distinct icon and color, separating it from the main checkout
 - Uses `--no-optional-locks` on all git calls to prevent lock contention
 - Fixes model name bleeding across sessions ([CC bug](https://github.com/anthropics/claude-code/issues/19570))
 - Validates model names to filter garbled input from Claude Code

--- a/statusline.sh
+++ b/statusline.sh
@@ -334,6 +334,8 @@ sep="  "
 # Git branch + uncommitted diff stats (tracked + untracked)
 branch=""
 diff_stat=""
+branch_glyph="⌥"          # main checkout
+branch_color="\033[36m"   # cyan
 if [ -n "$cwd" ]; then
   branch=$(git --no-optional-locks -C "$cwd" rev-parse --abbrev-ref HEAD 2>/dev/null)
   # Detached HEAD: show short SHA instead of literal "HEAD"
@@ -341,6 +343,21 @@ if [ -n "$cwd" ]; then
   # Empty repo (no commits): fall back to symbolic ref for branch name
   [ -z "$branch" ] && branch=$(git --no-optional-locks -C "$cwd" symbolic-ref --short HEAD 2>/dev/null)
   if [ -n "$branch" ]; then
+    # Worktree indicator: in a linked worktree the per-worktree git dir
+    # (.git/worktrees/<name>) differs from the shared --git-common-dir (.git);
+    # in the main checkout they're identical. Covers nested, sibling, and
+    # detached-HEAD worktrees regardless of whether cwd is the top or a subdir.
+    # --path-format=absolute forces --git-dir and --git-common-dir to the same
+    # (absolute) form; without it, from a subdir of the main checkout git prints
+    # git-dir absolute but common-dir relative, so the string compare below would
+    # false-positive a plain main checkout as a worktree.
+    gitdirs=$(git --no-optional-locks -C "$cwd" rev-parse --path-format=absolute --git-dir --git-common-dir 2>/dev/null)
+    gd=$(printf '%s\n' "$gitdirs" | sed -n '1p')
+    gcd=$(printf '%s\n' "$gitdirs" | sed -n '2p')
+    if [ -n "$gd" ] && [ "$gd" != "$gcd" ]; then
+      branch_glyph="⧉"                # worktree = a parallel copy of the repo
+      branch_color="\033[38;5;147m"   # light periwinkle, distinct from the cyan main checkout
+    fi
     added=0
     removed=0
     # Tracked changes require at least one commit
@@ -459,7 +476,7 @@ fi
 # ─── Line 1: branch, diff, model, context, tpm ───
 
 if [ -n "$branch" ]; then
-  printf "\033[36m⌥ %s${reset}" "$branch"
+  printf "${branch_color}${branch_glyph} %s${reset}" "$branch"
   printf "%b" "$diff_stat"
   printf "%s" "$sep"
 fi

--- a/statusline.sh
+++ b/statusline.sh
@@ -356,7 +356,7 @@ if [ -n "$cwd" ]; then
     gcd=$(printf '%s\n' "$gitdirs" | sed -n '2p')
     if [ -n "$gd" ] && [ "$gd" != "$gcd" ]; then
       branch_glyph="⧉"                # worktree = a parallel copy of the repo
-      branch_color="\033[38;5;147m"   # light periwinkle, distinct from the cyan main checkout
+      branch_color="\033[38;5;182m"   # light mauve, distinct from the cyan main checkout
     fi
     added=0
     removed=0

--- a/test/git.bats
+++ b/test/git.bats
@@ -62,3 +62,32 @@ load 'helpers'
   [[ "$(plain)" != *"⌥"* ]]
   [[ "$(plain)" == *"✦ Opus 4.6"* ]]
 }
+
+@test "git: main checkout uses the main-checkout glyph" {
+  TEST_GIT_REPO=$(mktemp -d)
+  git -C "$TEST_GIT_REPO" init -b main >/dev/null 2>&1
+  git -C "$TEST_GIT_REPO" -c user.name=test -c user.email=test@test commit --allow-empty -m "init" >/dev/null 2>&1
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "$TEST_GIT_REPO"
+  [[ "$(plain)" == *"⌥ main"* ]]
+  [[ "$(plain)" != *"⧉"* ]]
+}
+
+@test "git: linked worktree uses the worktree glyph" {
+  TEST_GIT_REPO=$(mktemp -d)
+  git -C "$TEST_GIT_REPO" init -b main >/dev/null 2>&1
+  git -C "$TEST_GIT_REPO" -c user.name=test -c user.email=test@test commit --allow-empty -m "init" >/dev/null 2>&1
+  git -C "$TEST_GIT_REPO" -c user.name=test -c user.email=test@test worktree add -b feature "$TEST_GIT_REPO/.worktrees/feature" >/dev/null 2>&1
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "$TEST_GIT_REPO/.worktrees/feature"
+  [[ "$(plain)" == *"⧉ feature"* ]]
+  [[ "$(plain)" != *"⌥"* ]]
+}
+
+@test "git: subdir of main checkout is not mistaken for a worktree" {
+  TEST_GIT_REPO=$(mktemp -d)
+  git -C "$TEST_GIT_REPO" init -b main >/dev/null 2>&1
+  git -C "$TEST_GIT_REPO" -c user.name=test -c user.email=test@test commit --allow-empty -m "init" >/dev/null 2>&1
+  mkdir -p "$TEST_GIT_REPO/subdir"
+  run run_sl "Opus 4.6" 25 "$TEST_SID" 60000 5000 3000 "$TEST_GIT_REPO/subdir"
+  [[ "$(plain)" == *"⌥ main"* ]]
+  [[ "$(plain)" != *"⧉"* ]]
+}


### PR DESCRIPTION
Closes #30.

## Summary
- Show a distinct icon and color for a linked git worktree (`⧉`, periwinkle) versus the main checkout (`⌥`, cyan), so the working copy is identifiable at a glance when several worktrees of one repo are open
- Detect a worktree by comparing the per-worktree `--git-dir` against the shared `--git-common-dir`; force `--path-format=absolute` so a subdirectory of the main checkout isn't mistaken for a worktree
- Handles nested, sibling, and detached-HEAD worktrees, whether the current directory is the worktree top or a subdirectory of it

## Test plan
- [x] `bats test/` — 125 pass, 0 fail (3 new git tests)
- [x] Manual: main checkout top + subdir render `⌥` (cyan); worktree top + subdir render `⧉` (periwinkle)
- New tests: linked worktree uses the worktree glyph; main checkout uses the main-checkout glyph; subdir of main checkout is not mistaken for a worktree

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only git metadata in the statusline script; no auth, data, or API changes.
> 
> **Overview**
> The statusline branch segment now uses **two visual modes**: main checkout stays **⌥** (cyan); a **linked git worktree** shows **⧉** (light mauve) so multiple checkouts of one repo are easy to tell apart.
> 
> Worktree detection compares `git rev-parse` **`--git-dir`** vs **`--git-common-dir`** with **`--path-format=absolute`**, avoiding false worktree detection when the cwd is a subdirectory of the main tree. Branch rendering uses configurable `branch_glyph` / `branch_color` instead of a hard-coded cyan ⌥.
> 
> **README** notes the worktree indicator. **Three bats tests** cover main checkout, linked worktree, and main-repo subdir.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7144f548552eb9f7bfa26025b5ff6d5b7bd68daf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Git branch status now uses distinct icons and colors for linked worktrees versus the main checkout.
  * Detection works across nested and sibling worktree layouts, including detached worktree scenarios.

* **Documentation**
  * Updated notes to describe the new linked-worktree indicator.

* **Tests**
  * Added coverage for main checkouts, linked worktrees, and subdirectory detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->